### PR TITLE
Add Gmail URL parsing and decoding support, along with comprehensive …

### DIFF
--- a/unfurl/parsers/__init__.py
+++ b/unfurl/parsers/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "parse_dropbox",
     "parse_facebook",
     "parse_duckduckgo",
+    "parse_gmail",
     "parse_google",
     "parse_hash",
     "parse_initial_node",

--- a/unfurl/parsers/parse_gmail.py
+++ b/unfurl/parsers/parse_gmail.py
@@ -1,0 +1,327 @@
+# Copyright 2026 Ryan Benson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import re
+
+import logging
+log = logging.getLogger(__name__)
+
+gmail_edge = {
+    'color': {
+        'color': '#ea4335'
+    },
+    'title': 'Gmail ID Parsing Functions',
+    'label': '✉'
+}
+
+# Legacy Gmail message/thread IDs are 15-16 hex digits (16 digits starting Nov 2004).
+legacy_id_re = re.compile(r'^[0-9a-fA-F]{15,16}$')
+
+# New-style Gmail web tokens (2018+ interface) use a 40-character alphabet of
+# upper- and lowercase consonants only. Observed tokens are 32 characters; the bound is a
+# floor rather than an exact length in case shorter ones exist, but anything shorter than
+# 32 is currently ignored.
+new_token_re = re.compile(r'^[b-df-hj-np-tv-zB-DF-HJ-NP-TV-Z]{32,}$')
+
+# Decoded form of a Gmail ID: thread or message, server-assigned (f) or client-assigned
+# (a), followed by the decimal ID. Client-assigned IDs have an "r" prefix and are signed,
+# so they can be negative (they are random 64-bit values, not timestamps).
+gmail_id_re = re.compile(r'(?P<kind>thread|msg)-(?P<style>[af]):(?P<digits>r?-?\d{1,20})')
+
+# One reference inside a decoded new-style token payload. Unlike the canonical form above,
+# the payload names only the style and ID for a thread ("f:1834...") and adds a "msg-"
+# keyword for a message ("msg-a:r-805..."); there is no "thread" keyword in the data.
+token_ref_re = re.compile(r'(?:(?P<kind>msg)-)?(?P<style>[af]):(?P<digits>r?-?\d{1,20})')
+
+base64_alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+reduced_alphabet = 'BCDFGHJKLMNPQRSTVWXZbcdfghjklmnpqrstvwxz'
+
+# Gmail launched on 2004-04-01; treat embedded timestamps outside 2004-2035 as
+# not plausible to keep false positives down.
+min_reasonable_ms = 1080777600000  # 2004-04-01
+max_reasonable_ms = 2051222400000  # 2035-01-01
+
+metaspike_ref = (
+    '<a href="https://www.metaspike.com/dates-gmail-message-id-thread-id-timestamps/" '
+    'target="_blank">[ref: Metaspike]</a>')
+arsenal_ref = (
+    '<a href="https://github.com/ArsenalRecon/GmailURLDecoder" '
+    'target="_blank">[ref: Arsenal Recon]</a>')
+
+
+def decode_new_style_token(token):
+    """Decode a new-style Gmail web token into its raw payload string.
+
+    The token is a big integer written in a 40-character alphabet (consonants only);
+    converting it to the standard base64 alphabet and base64-decoding the result yields
+    the payload, e.g. "f:1834473457053461654". Based on research and implementation by
+    Arsenal Recon (https://github.com/ArsenalRecon/GmailURLDecoder).
+
+    The payload is returned exactly as decoded. Arsenal Recon's implementation prepends
+    "thread-" when the decoded string lacks it, so the result reads like a Gmail API ID,
+    but no observed token contains that keyword -- 17 view tokens decoded to "f:<id>" and
+    2 compose tokens to "a:<id>+msg-a:<id>" forms. Adding it here would misreport what the
+    URL actually held, and it also hid every reference after the first in a multi-draft
+    compose token, since only the first got a keyword the ID regex could match.
+
+    Returns None for anything that doesn't decode, including tokens containing
+    characters outside the alphabet.
+    """
+    value = 0
+    for char in token:
+        position = reduced_alphabet.find(char)
+        if position == -1:
+            return None
+        value = value * 40 + position
+
+    b64_digits = []
+    while value:
+        b64_digits.append(base64_alphabet[value % 64])
+        value //= 64
+    b64_string = ''.join(reversed(b64_digits))
+
+    try:
+        padding = '=' * (-len(b64_string) % 4)
+        decoded = base64.b64decode(b64_string + padding).decode('utf-8')
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+    return decoded
+
+
+def parse_decoded_payload(decoded):
+    """Split a decoded new-style token payload into canonical Gmail IDs.
+
+    Observed payload shapes:
+        f:1834473457053461654                            a thread (viewing a message)
+        a:r-72...+msg-a:r-80...                          one draft: its thread and message
+        a:r-21...+msg-a:r-45...,a:r-31...+msg-a:r-38...  two drafts, comma-separated
+
+    A reference carrying no "msg-" keyword is the thread. The IDs returned use the
+    canonical "thread-f:"/"msg-a:" notation that Gmail itself uses in print-view URLs and
+    the API, rather than the compact form the token carries; callers surface the raw
+    payload alongside so the transformation stays visible.
+
+    Returns [] unless every reference parses. A payload that is only half understood means
+    the format model is wrong, and quietly emitting the recognized half is exactly how a
+    multi-draft compose token used to lose an ID.
+    """
+    gmail_ids = []
+    for draft in decoded.split(','):
+        for reference in draft.split('+'):
+            reference_match = token_ref_re.fullmatch(reference)
+            if not reference_match:
+                return []
+            kind = reference_match.group('kind') or 'thread'
+            gmail_ids.append(
+                f'{kind}-{reference_match.group("style")}:{reference_match.group("digits")}')
+    return gmail_ids
+
+
+def parse_gmail_token(unfurl, node, token, kind):
+    """Recognize a Gmail URL token and start the chain that decodes it.
+
+    Each conversion gets its own node rather than jumping from the URL straight to a
+    timestamp, so that an examiner can see the hex value that was recognized, the decimal
+    notation it converts to, and which bits of it the timestamp came from.
+    """
+    if legacy_id_re.fullmatch(token):
+        # Only treat it as a Gmail ID if the embedded timestamp is plausible
+        if not min_reasonable_ms <= (int(token, 16) >> 20) <= max_reasonable_ms:
+            return
+        unfurl.add_to_queue(
+            data_type='gmail.id.hex', key=kind, value=token,
+            label=f'Gmail {kind.capitalize()} ID (hex): {token}',
+            hover=f'Gmail message and thread IDs are 64-bit values, written as {len(token)} hex '
+                  f'digits in legacy-interface URLs and message headers. {metaspike_ref}',
+            parent_id=node.node_id, incoming_edge_config=gmail_edge)
+
+    elif new_token_re.fullmatch(token):
+        decoded = decode_new_style_token(token)
+        if not decoded:
+            return
+        if not parse_decoded_payload(decoded):
+            log.debug(f'Gmail token "{token}" decoded to an unrecognized payload: "{decoded}"')
+            return
+        unfurl.add_to_queue(
+            data_type='gmail.token.payload', key=None, value=decoded,
+            label=f'Decoded token: {decoded}',
+            hover=f'New-style Gmail URL tokens are an obfuscated (base conversion + base64) form '
+                  f'of Gmail\'s internal IDs. This is the payload the token decodes to, shown '
+                  f'exactly as decoded. {arsenal_ref}',
+            parent_id=node.node_id, incoming_edge_config=gmail_edge)
+
+
+def parse_hex_id(unfurl, node):
+    """Split a legacy hex Gmail ID and convert it to the notation Gmail uses elsewhere.
+
+    In hex the split needs no arithmetic: the last 5 digits are the low 20 bits, and
+    everything before them is the arrival time in epoch milliseconds. The timestamp half is
+    handed to parse_timestamp as "epoch-hex-milliseconds" rather than converted here.
+    """
+    hex_id = str(node.value)
+    kind = str(node.key or 'thread')
+    timestamp_hex, low_bits_hex = hex_id[:-5], hex_id[-5:]
+
+    value = f'{kind}-f:{int(hex_id, 16)}'
+    unfurl.add_to_queue(
+        data_type='gmail.id', key=None, value=value, label=f'Gmail ID: {value}',
+        hover=f'The same 64-bit value in decimal, which Gmail uses internally, in '
+              f'print-view URLs, and in its API. {metaspike_ref}',
+        parent_id=node.node_id, incoming_edge_config=gmail_edge)
+
+    unfurl.add_to_queue(
+        data_type='epoch-hex-milliseconds', key=None, value=timestamp_hex,
+        label=f'{kind.capitalize()} Timestamp (hex, upper 44 bits): {timestamp_hex}',
+        hover=f'Dropping the last 5 hex digits of a Gmail ID leaves the {kind}\'s creation '
+              f'time as epoch milliseconds, still in hex. A thread\'s timestamp is that of '
+              f'its first message. {metaspike_ref}',
+        parent_id=node.node_id, incoming_edge_config=gmail_edge)
+
+    unfurl.add_to_queue(
+        data_type='descriptor', key=None, value=None,
+        label=f'Low 20 bits: {low_bits_hex}',
+        hover=f'The last 5 hex digits, which are not part of the timestamp. Their meaning is '
+              f'not publicly documented. {metaspike_ref}',
+        parent_id=node.node_id, incoming_edge_config=gmail_edge)
+
+
+def parse_token_payload(unfurl, node):
+    """Split a decoded token payload into the Gmail IDs it names.
+
+    A compose token carries one thread and one message per open draft, so a single token
+    can yield four or more IDs.
+    """
+    for value in parse_decoded_payload(str(node.value)):
+        unfurl.add_to_queue(
+            data_type='gmail.id', key=None, value=value, label=f'Gmail ID: {value}',
+            hover=f'The payload names a thread by its style letter alone and prefixes a message '
+                  f'with "msg-"; this is the same reference in the canonical notation Gmail uses '
+                  f'in print-view URLs and its API. {arsenal_ref}',
+            parent_id=node.node_id, incoming_edge_config=gmail_edge)
+
+
+def parse_gmail_id(unfurl, node):
+    """Parse a decoded Gmail ID ("thread-f:...", "msg-f:...", etc.) and add child nodes."""
+    id_match = gmail_id_re.fullmatch(str(node.value))
+    if not id_match:
+        return
+
+    kind = 'Thread' if id_match.group('kind') == 'thread' else 'Message'
+    digits = id_match.group('digits')
+
+    # The style letter, not the "r" prefix, is what says who assigned the ID.
+    if id_match.group('style') == 'a':
+        unfurl.add_to_queue(
+            data_type='description', key=None, value=None,
+            label=f'Client-assigned {kind} ID',
+            hover=f'Gmail IDs with an "-a:" style are assigned by the client (e.g. drafts and '
+                  f'sent messages) and do not embed a timestamp. {arsenal_ref}',
+            parent_id=node.node_id, incoming_edge_config=gmail_edge)
+        return
+
+    # Server-assigned ("-f:") IDs carry a timestamp, but only the plain unsigned decimal form
+    # can be read as one. An "r"-prefixed or negative "-f:" ID isn't a shape Gmail is known to
+    # produce; the ID node still stands on its own, so just don't claim a timestamp for it.
+    if not digits.isdigit():
+        return
+
+    # A hex ID was already split on its own node, where the split is just "drop the last 5
+    # digits"; repeating it here in decimal would show the same timestamp twice.
+    parent = unfurl.nodes.get(getattr(node, 'parent_id', None))
+    if parent is not None and parent.data_type == 'gmail.id.hex':
+        return
+
+    # The 64-bit value splits in two: the upper 44 bits are the timestamp, the low 20 are not.
+    # Both halves get a node, so the split is visible rather than implied by a bare result.
+    gmail_id = int(digits)
+    timestamp_ms = gmail_id >> 20
+    low_bits = gmail_id & 0xFFFFF
+    if not min_reasonable_ms <= timestamp_ms <= max_reasonable_ms:
+        return
+
+    unfurl.add_to_queue(
+        data_type='epoch-milliseconds', key=None, value=timestamp_ms,
+        label=f'{kind} Timestamp (upper 44 bits):\n{timestamp_ms}',
+        hover=f'Dropping the low 20 bits of a server-assigned ("-f:") Gmail ID leaves the '
+              f'{kind.lower()}\'s creation time as an epoch milliseconds timestamp (in hex). '
+              f'A thread\'s timestamp is that of its first message. {metaspike_ref}',
+        parent_id=node.node_id, incoming_edge_config=gmail_edge)
+
+    unfurl.add_to_queue(
+        data_type='descriptor', key=None, value=None,
+        label=f'Low 20 bits: 0x{low_bits:05x}',
+        hover=f'What remains of the 64-bit ID after the 44 timestamp bits. This part is not '
+              f'time-based and its meaning is not publicly documented. {metaspike_ref}',
+        parent_id=node.node_id, incoming_edge_config=gmail_edge)
+
+
+def run(unfurl, node):
+    # Each step of the decoding is its own node type, re-entering here as it is created.
+    if node.data_type == 'gmail.id.hex':
+        parse_hex_id(unfurl, node)
+        return
+
+    if node.data_type == 'gmail.token.payload':
+        parse_token_payload(unfurl, node)
+        return
+
+    if node.data_type == 'gmail.id':
+        parse_gmail_id(unfurl, node)
+        return
+
+    if not unfurl.preceding_domain_matches(node, 'mail.google.com'):
+        return
+
+    # Ex: https://mail.google.com/mail/u/0/#inbox/172ed79b0337c14f (legacy interface)
+    # Ex: https://mail.google.com/mail/u/0/#inbox/FMfcgzQbffcMwhxlgVgQNtfsQngqqzMQ
+    # Ex: https://mail.google.com/mail/u/0/#search/some+terms/172ed79b0337c14f
+    if node.data_type == 'url.fragment.anchor':
+        for segment in str(node.value).split('/'):
+            # The token when viewing a message identifies the conversation thread
+            parse_gmail_token(unfurl, node, segment, kind='thread')
+
+    elif node.data_type == 'url.query.pair':
+        # Ex: https://mail.google.com/mail/u/0/?ui=2&view=btop&th=172ed79b0337c14f
+        if node.key == 'th':
+            parse_gmail_token(unfurl, node, str(node.value), kind='thread')
+
+        # Ex: #inbox?compose=DmwnWrRttPGlHpKcnZZbTLNKvhcrbHCwqSlPTGxRbGKmxxLtHfwWkVjkTRHTkfHbTFkQvvVwHKKFtHZQ
+        # Legacy compose tokens can be a comma-separated list (multiple drafts open at once)
+        elif node.key == 'compose':
+            for token in str(node.value).split(','):
+                if token != 'new':
+                    parse_gmail_token(unfurl, node, token, kind='msg')
+
+        # Ex: #inbox/<token>?projector=1 (attachment opened in the preview overlay)
+        elif node.key == 'projector':
+            unfurl.add_to_queue(
+                data_type='descriptor', key=None, value=None,
+                label='Attachment preview was open',
+                hover='Gmail adds "projector=1" when an attachment is opened in the in-browser '
+                      'preview overlay, so the URL records that an attachment on this message '
+                      'was viewed.',
+                parent_id=node.node_id, incoming_edge_config=gmail_edge)
+
+        # Ex: ?view=pt&search=all&permmsgid=msg-f:1670936980932986545 (print view)
+        elif node.key in ('permmsgid', 'permthid'):
+            id_match = gmail_id_re.fullmatch(str(node.value))
+            if id_match:
+                unfurl.add_to_queue(
+                    data_type='gmail.id', key=None, value=id_match.group(0),
+                    label=f'Gmail ID: {id_match.group(0)}',
+                    hover=f'Permanent Gmail message/thread IDs, as seen in print view URLs '
+                          f'and the Gmail API. {metaspike_ref}',
+                    parent_id=node.node_id, incoming_edge_config=gmail_edge)

--- a/unfurl/parsers/parse_google.py
+++ b/unfurl/parsers/parse_google.py
@@ -278,6 +278,40 @@ def run(unfurl, node):
                         data_type='google.aqs', key=key, value=value,
                         parent_id=node.node_id, incoming_edge_config=google_edge)
 
+        elif node.key == 'authuser':
+            # Seen across Google properties; identifies which of the browser profile's
+            # signed-in accounts the request is for, by the order they were added.
+            position = str(node.value)
+            if position.isdigit():
+                index = int(position)
+                qualifier = 'default account' if index == 0 else 'an additional signed-in account'
+                label = f'Google account index {index} ({qualifier})'
+                hover = ('Google\'s "authuser" selects between accounts signed in to the same '
+                         'browser profile, numbered from 0 in the order they were added. A '
+                         'value above 0 means more than one account was signed in.')
+            else:
+                # Some flows use the account's email address rather than an index.
+                label = f'Account: {node.value}'
+                hover = ('Google\'s "authuser" selects between accounts signed in to the same '
+                         'browser profile; here it names the account directly.')
+            unfurl.add_to_queue(
+                data_type='descriptor', key=None, value=None, label=label, hover=hover,
+                parent_id=node.node_id, incoming_edge_config=google_edge)
+
+        elif node.key == 'dsh':
+            # Ex: dsh=S2034035022:1749584429440685 (sign-in flows on accounts.google.com).
+            # The second field is the time the flow started, in epoch microseconds.
+            dsh_match = re.fullmatch(r'S?(-?\d+):(\d{13,19})', str(node.value))
+            if dsh_match:
+                dsh_timestamp = int(dsh_match.group(2))
+                unfurl.add_to_queue(
+                    data_type='epoch-microseconds', key=None, value=dsh_timestamp,
+                    label=f'dsh Timestamp: {dsh_timestamp}',
+                    hover='Google sign-in URLs carry a "dsh" value whose second field is the '
+                          'time the sign-in flow was started, as epoch microseconds. This dates '
+                          'the sign-in attempt itself, not the account or the page content.',
+                    parent_id=node.node_id, incoming_edge_config=google_edge)
+
         elif node.key == 'ei':
             decoded_ei = utils.try_urlsafe_b64_decode(node.value, min_length=8)
             if decoded_ei is None:

--- a/unfurl/parsers/parse_timestamp.py
+++ b/unfurl/parsers/parse_timestamp.py
@@ -385,6 +385,32 @@ def decode_epoch_hex(seconds):
     }
 
 
+def decode_epoch_hex_milliseconds(milliseconds):
+    """Decode a hex string (big endian) of an Epoch milliseconds integer to a timestamp.
+
+    An Epoch milliseconds timestamp is an integer counting milliseconds since Jan 1 1970;
+    written in hex it is 11 digits for current dates. Gmail IDs embed one this way: the
+    upper 44 bits of the 64-bit ID are the message's arrival time, so dropping the last 5
+    hex digits of the ID leaves the timestamp in hex.
+
+    Useful values for ranges (all Jan-1 00:00:00):
+      2015: 14B1CB5D000
+      2025: 193B0DAF000
+      2030: 1B885BE1000
+
+    This is reached only when a parser types a node "epoch-hex-milliseconds" explicitly;
+    it is deliberately not part of the hex auto-detection below, where an 11-hex-digit
+    value is too weak a signal to guess from.
+    """
+    timestamp = decode_epoch_milliseconds(int(milliseconds, 16))
+
+    return {
+        'data_type': 'timestamp.epoch-milliseconds-hex',
+        'display_type': 'Epoch milliseconds (hex)',
+        'timestamp_value': timestamp['timestamp_value']
+    }
+
+
 def decode_windows_filetime_hex(intervals):
     """Decode a hex timestamp in Windows FileTime format to a human-readable timestamp.
 
@@ -457,6 +483,9 @@ def run(unfurl, node):
 
     elif node.data_type == 'epoch-hex-seconds':
         new_timestamp = decode_epoch_hex(node.value)
+
+    elif node.data_type == 'epoch-hex-milliseconds':
+        new_timestamp = decode_epoch_hex_milliseconds(node.value)
 
     # Otherwise, examine the value of the node and see if we can detect a reasonable timestamp
     else:

--- a/unfurl/tests/unit/test_gmail.py
+++ b/unfurl/tests/unit/test_gmail.py
@@ -1,0 +1,333 @@
+from unfurl.core import Unfurl
+from unfurl.parsers import parse_gmail
+import unittest
+
+
+def get_nodes_by_type(unfurl_instance, data_type):
+    return [n for n in unfurl_instance.nodes.values() if n.data_type == data_type]
+
+
+def parse_url(url):
+    test = Unfurl()
+    test.add_to_queue(data_type='url', key=None, value=url)
+    test.parse_queue()
+    return test
+
+
+class TestGmailTokenDecoding(unittest.TestCase):
+    """Tests of the new-style Gmail web token decoder.
+
+    The decoder returns the payload exactly as decoded. It must not invent a "thread-"
+    keyword: no observed token contains one, and adding it hides every reference after
+    the first in a multi-draft compose token.
+
+    Vectors marked "captured" came from real Gmail URLs. Constructed vectors were built by
+    encoding a payload in a shape those captures confirm.
+    """
+
+    def test_decode_captured_view_token(self):
+        """Ground truth: decodes to a thread whose timestamp is when the message arrived."""
+        decoded = parse_gmail.decode_new_style_token('FMfcgzQbffcMwhxlgVgQNtfsQngqqzMQ')
+        self.assertEqual(decoded, 'f:1834473457053461654')
+
+    def test_decode_captured_one_draft_compose_token(self):
+        """A compose token holds the draft's thread and message IDs, joined by "+".
+
+        Both are client-assigned, so both are negative.
+        """
+        decoded = parse_gmail.decode_new_style_token(
+            'GTvVlcSKjDPsKDHWvqZCTKmmgKbhqgbxKlfhjNjPKtqMrDXmxjvJDlprDkjgXFpGnCmFpRcRHHcQf')
+        self.assertEqual(decoded, 'a:r-7217035772637032756+msg-a:r-8051540162134737577')
+
+    def test_decode_captured_two_draft_compose_token(self):
+        """Two drafts open at once: one "thread+message" group per draft, comma-separated.
+
+        Only the first group would carry a keyword the canonical ID regex can match, so a
+        decoder that prepends "thread-" reports 3 of these 4 IDs.
+        """
+        decoded = parse_gmail.decode_new_style_token(
+            'FNSXwzPZgrkmzfHgRnCzjkTXdpRNKmnKBVFdrmGRHlNdnkNkTjrpsQKxZvgKDPZTQmJbhwPnkvvFmrzb'
+            'XSLKcjQLPWGSKfZBjJHffNGvgskvzkQRQZxPffLdvVFLfMtHvrqgsnDgDSRsjdHGxhrrzCSrFRjV')
+        self.assertEqual(
+            decoded,
+            'a:r-2185233177584497971+msg-a:r-4574659139915391891,'
+            'a:r-3186403482298088288+msg-a:r-3812694900594247056')
+
+    def test_no_captured_token_contains_a_thread_keyword(self):
+        """Guards the fix: "thread-" is canonical Gmail notation, but not what a token holds."""
+        for token in ('FMfcgzQbffcMwhxlgVgQNtfsQngqqzMQ',
+                      'GTvVlcSKjDPsKDHWvqZCTKmmgKbhqgbxKlfhjNjPKtqMrDXmxjvJDlprDkjgXFpGnCmFpRcRHHcQf'):
+            with self.subTest(token=token[:12]):
+                self.assertNotIn('thread', parse_gmail.decode_new_style_token(token))
+
+    def test_token_outside_alphabet_returns_none(self):
+        """Vowels and digits are not in the 40-character alphabet.
+
+        run() gates on new_token_re before calling this, but the function is public and
+        must not raise on input that never passed that gate.
+        """
+        self.assertIsNone(parse_gmail.decode_new_style_token('FMfcgzQbffcMwhxlgVgQNtfsQngqqzMa'))
+        self.assertIsNone(parse_gmail.decode_new_style_token('FMfcgzQbffcMwhxlgVgQNtfsQngqqzM1'))
+
+
+class TestDecodedPayloadParsing(unittest.TestCase):
+    """A payload names the style and ID for a thread, and adds "msg-" for a message."""
+
+    def test_view_payload_is_a_thread(self):
+        self.assertEqual(
+            parse_gmail.parse_decoded_payload('f:1834473457053461654'),
+            ['thread-f:1834473457053461654'])
+
+    def test_draft_payload_yields_thread_then_message(self):
+        self.assertEqual(
+            parse_gmail.parse_decoded_payload('a:r-72+msg-a:r-80'),
+            ['thread-a:r-72', 'msg-a:r-80'])
+
+    def test_every_draft_is_reported(self):
+        self.assertEqual(
+            parse_gmail.parse_decoded_payload('a:r-1+msg-a:r-2,a:r-3+msg-a:r-4,a:r-5+msg-a:r-6'),
+            ['thread-a:r-1', 'msg-a:r-2', 'thread-a:r-3',
+             'msg-a:r-4', 'thread-a:r-5', 'msg-a:r-6'])
+
+    def test_unrecognized_payload_yields_nothing(self):
+        """All or nothing: emitting the half we recognize is how an ID went missing before."""
+        for payload in ('f:123+something-else', 'not an id at all', 'x:123', ''):
+            with self.subTest(payload=payload):
+                self.assertEqual(parse_gmail.parse_decoded_payload(payload), [])
+
+
+class TestGmailUrls(unittest.TestCase):
+
+    def test_legacy_view_url(self):
+        """Legacy hex thread ID in the URL fragment.
+
+        Expected values are from Metaspike's published research:
+        https://www.metaspike.com/dates-gmail-message-id-thread-id-timestamps/
+        """
+        test = parse_url('https://mail.google.com/mail/u/0/#inbox/172ed79b0337c14f')
+
+        gmail_ids = get_nodes_by_type(test, 'gmail.id')
+        self.assertEqual(len(gmail_ids), 1)
+        self.assertEqual(gmail_ids[0].value, 'thread-f:1670509572574921039')
+
+        # A hex ID is split in hex, so its timestamp is decoded from the hex form.
+        timestamps = get_nodes_by_type(test, 'timestamp.epoch-milliseconds-hex')
+        self.assertEqual(len(timestamps), 1)
+        self.assertEqual(timestamps[0].value, '2020-06-25 21:54:34.675+00:00')
+
+    def test_legacy_th_query_param(self):
+        test = parse_url('https://mail.google.com/mail/?ui=2&view=btop&th=172ed79b0337c14f')
+
+        gmail_ids = get_nodes_by_type(test, 'gmail.id')
+        self.assertEqual(len(gmail_ids), 1)
+        self.assertEqual(gmail_ids[0].value, 'thread-f:1670509572574921039')
+
+    def test_new_style_view_url(self):
+        """Constructed "f:<id>" token; the FMfcg prefix falls out of the real payload shape."""
+        test = parse_url(
+            'https://mail.google.com/mail/u/0/#inbox/FMfcgxwJWXcxTwrHDtwgrlxcmNBnhwXw')
+
+        gmail_ids = get_nodes_by_type(test, 'gmail.id')
+        self.assertEqual(len(gmail_ids), 1)
+        self.assertEqual(gmail_ids[0].value, 'thread-f:1670936980932986545')
+
+        timestamps = get_nodes_by_type(test, 'timestamp.epoch-milliseconds')
+        self.assertEqual(len(timestamps), 1)
+        self.assertEqual(timestamps[0].value, '2020-06-30 15:08:03.049+00:00')
+
+    def test_new_style_search_url(self):
+        test = parse_url(
+            'https://mail.google.com/mail/u/0/#search/from%3Asomeone/FMfcgxwJWXcxTwrHDtwgrlxcmNBnhwXw')
+
+        gmail_ids = get_nodes_by_type(test, 'gmail.id')
+        self.assertEqual(len(gmail_ids), 1)
+        self.assertEqual(gmail_ids[0].value, 'thread-f:1670936980932986545')
+
+    def test_raw_decoded_payload_gets_its_own_node(self):
+        """The canonical ID is derived, so the form the URL actually held stays on the graph."""
+        test = parse_url(
+            'https://mail.google.com/mail/u/0/#inbox/FMfcgxwJWXcxTwrHDtwgrlxcmNBnhwXw')
+
+        payloads = get_nodes_by_type(test, 'gmail.token.payload')
+        self.assertEqual(len(payloads), 1)
+        self.assertEqual(payloads[0].value, 'f:1670936980932986545')
+
+    def test_legacy_hex_id_gets_its_own_node(self):
+        """The hex-to-decimal conversion is a step, so both forms are on the graph."""
+        test = parse_url('https://mail.google.com/mail/u/0/#inbox/172ed79b0337c14f')
+
+        hex_ids = get_nodes_by_type(test, 'gmail.id.hex')
+        self.assertEqual(len(hex_ids), 1)
+        self.assertEqual(hex_ids[0].value, '172ed79b0337c14f')
+
+    def test_hex_id_splits_into_timestamp_and_low_bits(self):
+        """In hex the split is just "drop the last 5 digits", and the halves reassemble.
+
+        The timestamp half is handed to parse_timestamp still in hex, rather than being
+        converted inside the Gmail parser.
+        """
+        test = parse_url('https://mail.google.com/mail/u/0/#inbox/172ed79b0337c14f')
+
+        hex_timestamps = get_nodes_by_type(test, 'epoch-hex-milliseconds')
+        self.assertEqual(len(hex_timestamps), 1)
+        self.assertEqual(hex_timestamps[0].value, '172ed79b033')
+
+        labels = [n.label for n in get_nodes_by_type(test, 'descriptor')]
+        self.assertIn('Low 20 bits: 7c14f', labels)
+
+        # The two halves are the original ID, in order and with nothing left over.
+        self.assertEqual('172ed79b033' + '7c14f', '172ed79b0337c14f')
+
+    def test_hex_id_is_not_also_split_in_decimal(self):
+        """The split is shown once, in the representation the URL used."""
+        test = parse_url('https://mail.google.com/mail/u/0/#inbox/172ed79b0337c14f')
+        self.assertEqual(get_nodes_by_type(test, 'epoch-milliseconds'), [])
+
+    def test_client_assigned_compose_url(self):
+        """A captured single-draft compose token: thread and message, both client-assigned."""
+        test = parse_url(
+            'https://mail.google.com/mail/u/0/#inbox?compose='
+            'GTvVlcSKjDPsKDHWvqZCTKmmgKbhqgbxKlfhjNjPKtqMrDXmxjvJDlprDkjgXFpGnCmFpRcRHHcQf')
+
+        gmail_ids = sorted(n.value for n in get_nodes_by_type(test, 'gmail.id'))
+        self.assertEqual(
+            gmail_ids,
+            ['msg-a:r-8051540162134737577', 'thread-a:r-7217035772637032756'])
+
+        # Client-assigned ("-a:") IDs do not embed a timestamp
+        self.assertEqual(get_nodes_by_type(test, 'timestamp.epoch-milliseconds'), [])
+        descriptions = [n for n in get_nodes_by_type(test, 'description')
+                        if n.label == 'Client-assigned Message ID']
+        self.assertEqual(len(descriptions), 1)
+
+    def test_two_draft_compose_url_reports_all_four_ids(self):
+        """Regression: this captured token reported 3 of its 4 IDs.
+
+        Prepending "thread-" to the payload gave the first draft's thread reference a
+        keyword the canonical ID regex could match, while every later draft's went
+        unmatched and was silently dropped.
+        """
+        test = parse_url(
+            'https://mail.google.com/mail/u/0/#drafts?compose='
+            'FNSXwzPZgrkmzfHgRnCzjkTXdpRNKmnKBVFdrmGRHlNdnkNkTjrpsQKxZvgKDPZTQmJbhwPnkvvFmrzb'
+            'XSLKcjQLPWGSKfZBjJHffNGvgskvzkQRQZxPffLdvVFLfMtHvrqgsnDgDSRsjdHGxhrrzCSrFRjV')
+
+        gmail_ids = sorted(n.value for n in get_nodes_by_type(test, 'gmail.id'))
+        self.assertEqual(
+            gmail_ids,
+            ['msg-a:r-3812694900594247056', 'msg-a:r-4574659139915391891',
+             'thread-a:r-2185233177584497971', 'thread-a:r-3186403482298088288'])
+
+        # Every reference is client-assigned, so none carries a timestamp.
+        self.assertEqual(get_nodes_by_type(test, 'timestamp.epoch-milliseconds'), [])
+        labels = [n.label for n in get_nodes_by_type(test, 'description')]
+        self.assertIn('Client-assigned Thread ID', labels)
+        self.assertIn('Client-assigned Message ID', labels)
+
+    def test_three_draft_compose_token_generalizes(self):
+        """Constructed from the captured two-draft shape, to confirm the loop is not fixed at two."""
+        test = parse_url(
+            'https://mail.google.com/mail/u/0/#inbox?compose='
+            'CbTKJnxzVpPjBdStgkjkwvwlWQLvXGchHJSxMsFRlptrshBvCWFQhfQTCVcVzNgTkrSzJLxZrWqtrwXz'
+            'PKcCtRmvGbxfTKnsltgkwQhMJbtxTNfJWgZMBRlfldFBxCbtgfDcJBsRzGdnbkGdQXPpLgnKfNmDFvQw'
+            'rzGGGBjVVswVGgZczGkHNMBJplmNHLqpCLbpDxQHCCsDpnLjcWTwqqjdLQFXmcvDlLbDFwllPq')
+
+        gmail_ids = get_nodes_by_type(test, 'gmail.id')
+        self.assertEqual(len(gmail_ids), 6)
+
+    def test_legacy_compose_list(self):
+        """Multiple drafts open at once produce a comma-separated compose token list."""
+        test = parse_url(
+            'https://mail.google.com/mail/u/0/#inbox?compose=172ed79b0337c14f%2Cffff3432161af8b')
+
+        gmail_ids = sorted(n.value for n in get_nodes_by_type(test, 'gmail.id'))
+        self.assertEqual(gmail_ids, ['msg-f:1152907499278544779', 'msg-f:1670509572574921039'])
+
+        # Both are hex IDs, so both are split and decoded in hex. The 15-digit ID drops the
+        # same 5 digits as the 16-digit one, leaving a shorter timestamp.
+        hex_timestamps = sorted(n.value for n in get_nodes_by_type(test, 'epoch-hex-milliseconds'))
+        self.assertEqual(hex_timestamps, ['172ed79b033', 'ffff343216'])
+
+        timestamps = sorted(
+            n.value for n in get_nodes_by_type(test, 'timestamp.epoch-milliseconds-hex'))
+        self.assertEqual(timestamps, ['2004-11-03 16:11:11.254+00:00', '2020-06-25 21:54:34.675+00:00'])
+
+    def test_permmsgid_query_param(self):
+        test = parse_url(
+            'https://mail.google.com/mail/u/0/?ui=2&view=pt&search=all&permmsgid=msg-f%3A1670936980932986545')
+
+        gmail_ids = get_nodes_by_type(test, 'gmail.id')
+        self.assertEqual(len(gmail_ids), 1)
+        self.assertEqual(gmail_ids[0].value, 'msg-f:1670936980932986545')
+
+        timestamps = get_nodes_by_type(test, 'timestamp.epoch-milliseconds')
+        self.assertEqual(len(timestamps), 1)
+        self.assertEqual(timestamps[0].value, '2020-06-30 15:08:03.049+00:00')
+
+    def test_real_captured_url(self):
+        test = parse_url('https://mail.google.com/mail/u/0/#inbox/FMfcgzQbffcMwhxlgVgQNtfsQngqqzMQ')
+
+        gmail_ids = get_nodes_by_type(test, 'gmail.id')
+        self.assertEqual(len(gmail_ids), 1)
+        self.assertEqual(gmail_ids[0].value, 'thread-f:1834473457053461654')
+
+        timestamps = get_nodes_by_type(test, 'timestamp.epoch-milliseconds')
+        self.assertEqual(len(timestamps), 1)
+        self.assertEqual(timestamps[0].value, '2025-06-09 17:30:20.120+00:00')
+
+    def test_projector_marks_an_opened_attachment(self):
+        """"projector=1" distinguishes viewing an attachment from opening the message."""
+        test = parse_url(
+            'https://mail.google.com/mail/u/0/#inbox/FMfcgzQbffcMwhxlgVgQNtfsQngqqzMQ?projector=1')
+
+        labels = [n.label for n in get_nodes_by_type(test, 'descriptor')]
+        self.assertIn('Attachment preview was open', labels)
+
+        # The thread token in the same fragment still parses.
+        gmail_ids = get_nodes_by_type(test, 'gmail.id')
+        self.assertEqual(len(gmail_ids), 1)
+        self.assertEqual(gmail_ids[0].value, 'thread-f:1834473457053461654')
+
+    def test_thread_url_without_projector_has_no_attachment_node(self):
+        test = parse_url('https://mail.google.com/mail/u/0/#inbox/FMfcgzQbffcMwhxlgVgQNtfsQngqqzMQ')
+        labels = [n.label for n in get_nodes_by_type(test, 'descriptor')]
+        self.assertNotIn('Attachment preview was open', labels)
+
+    def test_non_gmail_domain_is_ignored(self):
+        test = parse_url('https://example.com/mail/u/0/#inbox/172ed79b0337c14f')
+        self.assertEqual(get_nodes_by_type(test, 'gmail.id'), [])
+
+    def test_implausible_hex_id_is_ignored(self):
+        # 15 hex digits, but the embedded timestamp would be pre-Gmail (1970s)
+        test = parse_url('https://mail.google.com/mail/u/0/#inbox/00000432161af8b')
+        self.assertEqual(get_nodes_by_type(test, 'gmail.id'), [])
+
+
+class TestGmailIdStyles(unittest.TestCase):
+    """The style letter ("-f:" vs "-a:"), not the "r" prefix, says who assigned an ID."""
+
+    def parse_id(self, gmail_id):
+        test = Unfurl()
+        test.add_to_queue(data_type='gmail.id', key=None, value=gmail_id)
+        test.parse_queue()
+        return test
+
+    def test_client_assigned_id_is_labeled(self):
+        test = self.parse_id('msg-a:r1234567890123456789')
+        labels = [n.label for n in get_nodes_by_type(test, 'description')]
+        self.assertIn('Client-assigned Message ID', labels)
+
+    def test_server_assigned_id_with_r_prefix_is_not_called_client_assigned(self):
+        """An "-f:" ID is server-assigned regardless of an "r" prefix on the digits.
+
+        No timestamp can be read from that shape, but mislabeling the ID's origin would
+        be an affirmatively wrong forensic claim.
+        """
+        test = self.parse_id('thread-f:r1670936980932986545')
+        labels = [n.label for n in get_nodes_by_type(test, 'description')]
+        self.assertNotIn('Client-assigned Thread ID', labels)
+        self.assertEqual(get_nodes_by_type(test, 'timestamp.epoch-milliseconds'), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unfurl/tests/unit/test_google.py
+++ b/unfurl/tests/unit/test_google.py
@@ -1,6 +1,17 @@
 from unfurl.core import Unfurl
 from urllib.parse import urlparse
+import re
 import unittest
+
+
+def hover_text(node):
+    """A node's hover with markup removed and whitespace collapsed.
+
+    Hover text is wrapped for display, which inserts <br> at positions that depend on the
+    exact wording. Matching against the raw value makes an assertion pass or fail on where
+    a line break happened to land, so match against what the reader actually sees.
+    """
+    return ' '.join(re.sub(r'<[^>]+>', ' ', node.hover or '').split())
 
 
 def get_nodes_by_type(unfurl_instance, data_type):
@@ -135,7 +146,7 @@ class TestGoogle(unittest.TestCase):
         # confirm q has the redirect hover text
         q_node = next(n for n in test.nodes.values()
                       if n.data_type == 'url.query.pair' and n.key == 'q')
-        self.assertIn('redirect target', q_node.hover.lower())
+        self.assertIn('redirect target', hover_text(q_node).lower())
 
         # confirm the destination URL is parsed
         dest_urls = [
@@ -148,12 +159,12 @@ class TestGoogle(unittest.TestCase):
         # confirm sa has hover text
         sa_node = next(n for n in test.nodes.values()
                        if n.data_type == 'url.query.pair' and n.key == 'sa')
-        self.assertIn('action type', sa_node.hover.lower())
+        self.assertIn('action type', hover_text(sa_node).lower())
 
         # confirm usg has hover text
         usg_node = next(n for n in test.nodes.values()
                         if n.data_type == 'url.query.pair' and n.key == 'usg')
-        self.assertIn('signature', usg_node.hover.lower())
+        self.assertIn('signature', hover_text(usg_node).lower())
 
 
     def test_google_aclk_ad_click(self):
@@ -191,19 +202,64 @@ class TestGoogle(unittest.TestCase):
         ai_node = next(n for n in test.nodes.values()
                        if n.data_type == 'url.query.pair' and n.key == 'ai')
         self.assertIsNotNone(ai_node.hover)
-        self.assertIn('ad', ai_node.hover.lower())
+        self.assertIn('ad', hover_text(ai_node).lower())
 
         # sig should have hover text about signature
         sig_node = next(n for n in test.nodes.values()
                         if n.data_type == 'url.query.pair' and n.key == 'sig')
         self.assertIsNotNone(sig_node.hover)
-        self.assertIn('signature', sig_node.hover.lower())
+        self.assertIn('signature', hover_text(sig_node).lower())
 
         # gclid should have hover text
         gclid_node = next(n for n in test.nodes.values()
                           if n.data_type == 'url.query.pair' and n.key == 'gclid')
         self.assertIsNotNone(gclid_node.hover)
-        self.assertIn('click', gclid_node.hover.lower())
+        self.assertIn('click', hover_text(gclid_node).lower())
+
+
+class TestGoogleAccountParams(unittest.TestCase):
+    """Params seen on Google sign-in and multi-account URLs."""
+
+    def parse(self, url):
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None, value=url)
+        test.parse_queue()
+        return test
+
+    def test_dsh_timestamp(self):
+        """The second field of "dsh" dates the sign-in flow itself."""
+        test = self.parse(
+            'https://accounts.google.com/v3/signin/identifier?dsh=S2034035022%3A1749584429440685')
+
+        raw = get_nodes_by_type(test, 'epoch-microseconds')
+        self.assertEqual(1, len(raw))
+        self.assertEqual(1749584429440685, raw[0].value)
+
+        parsed = get_nodes_by_type(test, 'timestamp.epoch-microseconds')
+        self.assertEqual(1, len(parsed))
+        self.assertEqual('2025-06-10 19:40:29.440685+00:00', parsed[0].value)
+
+    def test_dsh_first_field_may_be_negative(self):
+        test = self.parse(
+            'https://accounts.google.com/v3/signin/challenge/pwd?dsh=S-905808778%3A1750788381554893')
+
+        parsed = get_nodes_by_type(test, 'timestamp.epoch-microseconds')
+        self.assertEqual(1, len(parsed))
+        self.assertEqual('2025-06-24 18:06:21.554893+00:00', parsed[0].value)
+
+    def test_malformed_dsh_yields_no_timestamp(self):
+        test = self.parse('https://accounts.google.com/v3/signin/identifier?dsh=nonsense')
+        self.assertEqual([], get_nodes_by_type(test, 'epoch-microseconds'))
+
+    def test_authuser_zero_is_the_default_account(self):
+        test = self.parse('https://www.google.com/search?q=dfir&authuser=0')
+        labels = [n.label for n in get_nodes_by_type(test, 'descriptor')]
+        self.assertIn('Google account index 0 (default account)', labels)
+
+    def test_authuser_above_zero_indicates_multiple_accounts(self):
+        test = self.parse('https://www.google.com/search?q=dfir&authuser=1')
+        labels = [n.label for n in get_nodes_by_type(test, 'descriptor')]
+        self.assertIn('Google account index 1 (an additional signed-in account)', labels)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…unit tests.

- Implement new parser for Gmail message and thread IDs, including both legacy and new token formats.
- Introduce unit tests for all decoding methods, payload parsing, and Gmail URL variations.
- Update parsers' entry point to include newly added Gmail parser.
- Enhance test suite coverage with various Gmail URL scenarios.

Fixes #45 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR