### PR TITLE
Refactor remote lookup logic and introduce comprehensive tests for sh…

### DIFF
--- a/unfurl/app.py
+++ b/unfurl/app.py
@@ -29,7 +29,7 @@ CORS(app)
 
 
 class UnfurlApp:
-    def __init__(self, unfurl_debug=False, unfurl_host='localhost', unfurl_port=5000, remote_lookups=False):
+    def __init__(self, unfurl_debug=False, unfurl_host='localhost', unfurl_port=5000, remote_lookups=None):
         self.unfurl_debug = unfurl_debug
         self.unfurl_host = unfurl_host
         self.unfurl_port = unfurl_port
@@ -95,7 +95,7 @@ class JsonVisJS(Resource):
             extra_options={'widthConstraint': {'maximum': 1200}})
 
 
-def web_app(host='localhost', port='5000', debug='True', remote_lookups=False):
+def web_app(host='localhost', port='5000', debug='True', remote_lookups=None):
 
     config = load_config()
     remote_lookups = resolve_remote_lookups(explicit=remote_lookups, config=config)

--- a/unfurl/cli.py
+++ b/unfurl/cli.py
@@ -34,7 +34,8 @@ def command_line_interface():
     parser.add_argument(
         '-f', '--filter', help='only output lines that match this filter.')
     parser.add_argument(
-        '-l', '--lookups', help='allow remote lookups to enhance results.', action='store_true')
+        '-l', '--lookups', help='allow remote lookups to enhance results.',
+        action='store_true', default=None)
     parser.add_argument(
         '-o', '--output',
         help='file to save output (as CSV) to. if omitted, output is sent to '

--- a/unfurl/core.py
+++ b/unfurl/core.py
@@ -93,15 +93,21 @@ def remote_lookups_from_env():
     return enabled
 
 
-def resolve_remote_lookups(explicit=False, config=None):
+def resolve_remote_lookups(explicit=None, config=None):
     """Decide whether remote lookups are allowed, disabled unless something enables them.
 
-    Precedence: an explicit request (the CLI's -l, which can only turn them on), then
-    UNFURL_REMOTE_LOOKUPS, then the config files. The environment beats the config file
-    so that a container can enable lookups without editing the mounted unfurl.ini.
+    Precedence: an explicit True *or False* from the caller, then UNFURL_REMOTE_LOOKUPS,
+    then the config files. The environment beats the config file so that a container can
+    enable lookups without editing the mounted unfurl.ini.
+
+    `explicit=None` means "not specified" and defers to the environment and config, which
+    matches remote_lookups_from_env(). This used to test `if explicit:`, so False was
+    indistinguishable from unspecified and `Unfurl(remote_lookups=False)` could not turn
+    lookups off -- on a machine with them enabled in unfurl.ini it silently made real
+    requests. Callers that want to defer must pass None, not False.
     """
-    if explicit:
-        return True
+    if explicit is not None:
+        return bool(explicit)
 
     from_env = remote_lookups_from_env()
     if from_env is not None:
@@ -677,7 +683,7 @@ class Unfurl:
         return text_output
 
 
-def run(url, data_type='url', return_type='json', remote_lookups=False, extra_options=None):
+def run(url, data_type='url', return_type='json', remote_lookups=None, extra_options=None):
     u = Unfurl(remote_lookups=remote_lookups)
     u.add_to_queue(
         data_type=data_type,

--- a/unfurl/parsers/parse_shortlink.py
+++ b/unfurl/parsers/parse_shortlink.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import requests
 import json
 
 from bs4 import BeautifulSoup
+
+log = logging.getLogger(__name__)
 
 
 shortlink_edge = {
@@ -41,12 +44,46 @@ def expand_bitly_url(bitlink_id, api_key):
         return {}
 
 def parse_linkedin_slink_url(shortcode):
+    """Expand a LinkedIn short link by scraping its interstitial page.
+
+    LinkedIn serves an "are you sure you want to leave" page rather than redirecting, so
+    the destination has to be read out of the markup. That makes this the most brittle
+    expander here: the selector depends on LinkedIn's page structure, which carries no
+    compatibility promise and is not served at all to a client LinkedIn declines to
+    answer -- a sign-in wall, a rate limit, or a datacenter IP being turned away.
+
+    Every one of those cases has to return empty rather than raise. `run_plugins`
+    catches exceptions, so raising here still "worked", but it logged a traceback and
+    told an analyst nothing about whether the link failed to expand or was never tried.
+    """
+
     r = requests.get(url=f'https://www.linkedin.com/slink?code={shortcode}', timeout=3)
+
+    if r.status_code != 200:
+        # 999 is LinkedIn's own "no thanks" status for clients it declines to serve.
+        log.warning(
+            f'LinkedIn returned HTTP {r.status_code} for short link "{shortcode}"; '
+            f'cannot expand it.')
+        return {}
+
     soup = BeautifulSoup(r.content, 'html.parser')
-    link = soup.select_one("main a.artdeco-button")
-    if link.get('href'):
-        return link.get('href')
-    return {}
+
+    # Scoped to <main> on purpose: LinkedIn puts a "learn more" link with the same
+    # artdeco-button class elsewhere on the page, and expanding to that would report
+    # LinkedIn's own help article as this link's destination.
+    link = soup.select_one('main a.artdeco-button')
+    if link is None:
+        log.warning(
+            f'No destination link found on the LinkedIn interstitial for "{shortcode}". '
+            f'LinkedIn may have changed the page, or declined to serve it.')
+        return {}
+
+    href = link.get('href')
+    if not href:
+        log.warning(f'LinkedIn interstitial for "{shortcode}" had a link with no href.')
+        return {}
+
+    return href
 
 
 def expand_vdg_url(shortcode):

--- a/unfurl/tests/http_mocks.py
+++ b/unfurl/tests/http_mocks.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Ryan Benson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fake HTTP responses, so parsers that reach out to a service can be tested offline.
+
+Tests that make real requests are testing two different things at once: our code, and
+whether some third party still behaves the way we assumed. Those deserve to fail
+separately -- a LinkedIn markup change is not a regression in Unfurl, and a Unfurl
+regression should not need LinkedIn to be reachable to show up. The mocks here cover the
+first; `unfurl/tests/live/` covers the second.
+
+Responses are modeled on captured real ones. Where a detail of the real response matters
+to the code under test, it is reproduced rather than idealized -- see the note on header
+case in `FakeResponse`.
+"""
+
+import json as json_module
+from unittest import mock
+
+import requests
+from requests.structures import CaseInsensitiveDict
+
+
+class FakeResponse:
+    """A stand-in for requests.Response covering what Unfurl's parsers touch.
+
+    Headers use requests' own CaseInsensitiveDict on purpose. Real shorteners send
+    a lowercase "location" header, while `expand_url_via_redirect_header` reads
+    `r.headers['Location']`. That only works because requests is case-insensitive, so a
+    mock built on a plain dict would either hide the dependency or fail for a reason the
+    real world never produces.
+    """
+
+    def __init__(self, status_code=200, headers=None, content=b'', json=None, url=''):
+        self.status_code = status_code
+        self.headers = CaseInsensitiveDict(headers or {})
+        self.url = url
+
+        if json is not None:
+            content = json_module.dumps(json).encode('utf-8')
+        if isinstance(content, str):
+            content = content.encode('utf-8')
+
+        self.content = content
+        self._json = json
+
+    @property
+    def text(self):
+        return self.content.decode('utf-8', errors='replace')
+
+    def json(self):
+        if self._json is not None:
+            return self._json
+        return json_module.loads(self.text)
+
+
+def redirect(location, status_code=301):
+    """A shortener's redirect response."""
+
+    return FakeResponse(status_code=status_code, headers={'location': location})
+
+
+def routed_get(routes, default=None):
+    """Build a requests.get replacement that answers based on the requested URL.
+
+    `routes` maps a substring of the URL to a FakeResponse. Anything unmatched gets
+    `default`, which is a 404 unless given -- an unexpected outbound call should look
+    like a miss rather than silently receiving another route's answer.
+
+    Returns (replacement_callable, calls_list); calls_list records the URLs requested.
+    """
+
+    calls = []
+
+    def fake_get(url, *args, **kwargs):
+        calls.append(url)
+        for fragment, response in routes.items():
+            if fragment in url:
+                return response
+        return default if default is not None else FakeResponse(status_code=404)
+
+    return fake_get, calls
+
+
+def patch_requests_get(routes, default=None):
+    """Context manager patching requests.get with a routed fake.
+
+    Yields the list of requested URLs, so a test can assert on what was called -- and,
+    just as usefully, on what was not.
+    """
+
+    fake_get, calls = routed_get(routes, default=default)
+
+    class _Patch:
+        def __enter__(self):
+            self._patcher = mock.patch.object(requests, 'get', side_effect=fake_get)
+            self._patcher.start()
+            return calls
+
+        def __exit__(self, *exc_info):
+            self._patcher.stop()
+            return False
+
+    return _Patch()

--- a/unfurl/tests/live/test_shortlink_live.py
+++ b/unfurl/tests/live/test_shortlink_live.py
@@ -1,0 +1,84 @@
+"""Live contract tests for URL shorteners.
+
+These make real network requests. They are not testing Unfurl -- `tests/unit/test_shortlink.py`
+does that offline -- they are testing whether the third parties still behave the way
+Unfurl assumes. A failure here means the outside world changed, which is useful to know
+but is not a code regression, and should not turn a pull request red.
+
+Run them on purpose:
+
+    UNFURL_LIVE_TESTS=1 python -m unittest discover -s unfurl/tests/live -t .
+
+They are skipped otherwise, including in CI, which runs the whole suite across nine
+Python/OS combinations -- nine rounds of requests at LinkedIn and t.co per push, from
+datacenter IPs that shorteners are prone to turning away.
+
+The URLs below are long-lived public links, but they are still someone else's data: if
+one is deleted the test fails through no fault of the code. Prefer adding assertions
+about *shape* (a redirect was returned, an anchor was found) over assertions about
+particular destinations.
+"""
+
+import os
+import unittest
+
+from unfurl.core import Unfurl
+from unfurl.parsers.parse_shortlink import expand_url_via_redirect_header, parse_linkedin_slink_url
+
+
+LIVE_TESTS_ENABLED = os.environ.get('UNFURL_LIVE_TESTS') == '1'
+
+requires_network = unittest.skipUnless(
+    LIVE_TESTS_ENABLED,
+    'set UNFURL_LIVE_TESTS=1 to run tests that make real network requests')
+
+
+def has_node(unfurl_instance, **criteria):
+    for node in unfurl_instance.nodes.values():
+        if all(getattr(node, attr, None) == val for attr, val in criteria.items()):
+            return True
+    return False
+
+
+@requires_network
+class TestShortlinkContracts(unittest.TestCase):
+
+    def test_tco_still_answers_with_a_redirect(self):
+        """t.co is expected to 3xx with a Location header."""
+
+        expanded = expand_url_via_redirect_header('https://t.co/', 'g6VWYYwY12')
+
+        self.assertTrue(expanded, 'expected a Location header from t.co')
+        self.assertTrue(str(expanded).startswith('http'))
+
+    def test_linkedin_interstitial_still_has_the_expected_anchor(self):
+        """The selector "main a.artdeco-button" is the fragile part of this parser.
+
+        It depends on LinkedIn's page markup, which we do not control and which carries
+        no compatibility promise.
+        """
+
+        expanded = parse_linkedin_slink_url('fDJnJ64')
+
+        self.assertTrue(expanded, 'no anchor matched "main a.artdeco-button"')
+        self.assertTrue(str(expanded).startswith('http'))
+
+    def test_twitter_shortlink_end_to_end(self):
+        test = Unfurl(remote_lookups=True)
+        test.add_to_queue(data_type='url', key=None, value='https://t.co/g6VWYYwY12')
+        test.parse_queue()
+
+        self.assertTrue(has_node(test, value='/g6VWYYwY12'))
+        self.assertTrue(has_node(test, value='github.com'))
+
+    def test_linkedin_shortlink_end_to_end(self):
+        test = Unfurl(remote_lookups=True)
+        test.add_to_queue(data_type='url', key=None, value='https://lnkd.in/fDJnJ64')
+        test.parse_queue()
+
+        self.assertTrue(has_node(test, value='/fDJnJ64'))
+        self.assertTrue(has_node(test, value='thisweekin4n6.com'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unfurl/tests/unit/test_remote_lookups.py
+++ b/unfurl/tests/unit/test_remote_lookups.py
@@ -44,9 +44,45 @@ class TestResolveRemoteLookups(unittest.TestCase):
             self.assertFalse(resolve_remote_lookups(config=make_config('true')))
 
     def test_explicit_request_beats_environment(self):
-        """The CLI's -l is opt-in per run, so it wins; it can only ever enable."""
+        """An explicit choice is per-run, so it wins over environment and config."""
         with patch.dict(os.environ, {REMOTE_LOOKUPS_ENV_VAR: 'false'}):
             self.assertTrue(resolve_remote_lookups(explicit=True, config=make_config('false')))
+
+    def test_explicit_false_beats_environment_and_config(self):
+        """False must mean "off", not "unspecified".
+
+        This tested `if explicit:` originally, so False fell through to the environment
+        and config and `Unfurl(remote_lookups=False)` could not turn lookups off. On a
+        machine with lookups enabled in unfurl.ini that silently made real network
+        requests -- including from tests that had asked for them to be off.
+        """
+        with patch.dict(os.environ, {REMOTE_LOOKUPS_ENV_VAR: 'true'}):
+            self.assertFalse(resolve_remote_lookups(explicit=False, config=make_config('true')))
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(resolve_remote_lookups(explicit=False, config=make_config('true')))
+
+    def test_none_defers_to_environment_and_config(self):
+        """None is how a caller says "not specified"; it must not force lookups off."""
+        with patch.dict(os.environ, {REMOTE_LOOKUPS_ENV_VAR: 'true'}):
+            self.assertTrue(resolve_remote_lookups(explicit=None, config=make_config('false')))
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(resolve_remote_lookups(explicit=None, config=make_config('true')))
+
+    def test_resolution_is_idempotent(self):
+        """Feeding a resolved answer back in must return that same answer.
+
+        app.py resolves once in web_app() and the resolved boolean is passed down through
+        run() into Unfurl, where it is resolved again.
+        """
+        with patch.dict(os.environ, {REMOTE_LOOKUPS_ENV_VAR: 'true'}):
+            once = resolve_remote_lookups(config=make_config())
+            self.assertEqual(once, resolve_remote_lookups(explicit=once, config=make_config()))
+
+        with patch.dict(os.environ, {REMOTE_LOOKUPS_ENV_VAR: 'false'}):
+            once = resolve_remote_lookups(config=make_config())
+            self.assertEqual(once, resolve_remote_lookups(explicit=once, config=make_config()))
 
     def test_unset_environment_defers_to_config(self):
         with patch.dict(os.environ, {}, clear=True):
@@ -105,6 +141,37 @@ class TestUnfurlHonorsEnvironment(unittest.TestCase):
     def test_explicit_request_still_wins(self):
         with patch.dict(os.environ, {REMOTE_LOOKUPS_ENV_VAR: 'false'}):
             self.assertTrue(Unfurl(remote_lookups=True).remote_lookups)
+
+    def test_explicit_false_disables_lookups_on_a_new_instance(self):
+        """Unfurl(remote_lookups=False) has to actually mean offline.
+
+        Tests rely on this to stay off the network, and an analyst relies on it to keep
+        evidence from being sent to third parties.
+        """
+        with patch.dict(os.environ, {REMOTE_LOOKUPS_ENV_VAR: 'true'}):
+            self.assertFalse(Unfurl(remote_lookups=False).remote_lookups)
+
+    def test_default_construction_defers_to_environment(self):
+        """Unfurl() must keep honoring the environment, not default to off."""
+        with patch.dict(os.environ, {REMOTE_LOOKUPS_ENV_VAR: 'true'}):
+            self.assertTrue(Unfurl().remote_lookups)
+
+
+class TestRunHonorsRemoteLookups(unittest.TestCase):
+    """core.run() is the public entry point the web app and library callers use.
+
+    Its default changed from False to None so that "not specified" stays distinguishable
+    from "off" -- with a False default, fixing the resolver would have made run() ignore
+    UNFURL_REMOTE_LOOKUPS and unfurl.ini entirely.
+    """
+
+    def setUp(self):
+        core._warned_about_env_remote_lookups = False
+
+    def test_default_is_none_so_the_environment_still_applies(self):
+        import inspect
+        default = inspect.signature(core.run).parameters['remote_lookups'].default
+        self.assertIsNone(default, 'a False default would override env/config')
 
 
 if __name__ == '__main__':

--- a/unfurl/tests/unit/test_shortlink.py
+++ b/unfurl/tests/unit/test_shortlink.py
@@ -1,4 +1,5 @@
 from unfurl.core import Unfurl
+from unfurl.tests.http_mocks import FakeResponse, patch_requests_get, redirect
 import unittest
 
 
@@ -15,67 +16,242 @@ def has_node(unfurl_instance, **criteria):
     return find_node(unfurl_instance, **criteria) is not None
 
 
-class TestShortLinks(unittest.TestCase):
+def expanded_nodes(unfurl_instance):
+    return [node for node in unfurl_instance.nodes.values()
+            if str(node.label).startswith('Expanded URL')]
+
+
+# Captured from https://lnkd.in/fDJnJ64. Trimmed to the structure the parser depends on,
+# with the wording and attributes left as LinkedIn sends them.
+#
+# The second artdeco-button is deliberate: LinkedIn puts a "learn more" link on the same
+# page with the same class, outside <main>. It is what makes the "main " part of the
+# selector load-bearing, so a fixture without it would let a broken selector pass.
+LINKEDIN_INTERSTITIAL = """<!DOCTYPE html>
+<html lang="en">
+<body>
+<main class="main">
+<span class="sr-only">LinkedIn</span>
+<h1 class="t-24 t-bold t-black mb2">This link will take you to a page that's not on LinkedIn</h1>
+<h2 class="t-16 t-black mb3">Because this is an external link, we're unable to verify it for safety.</h2>
+<a class="artdeco-button artdeco-button--tertiary"
+   data-tracking-control-name="external_url_click" data-tracking-will-navigate
+   href="https://thisweekin4n6.com/2020/04/19/week-16-2020/">Continue</a>
+</main>
+<footer>
+<a class="t-14 artdeco-button artdeco-button--tertiary"
+   data-tracking-control-name="learn_more_click" data-tracking-will-navigate
+   href="https://www.linkedin.com/help/linkedin/answer/a1341680?trk=in_page_learn_more_click"
+   target="_blank">Learn more</a>
+</footer>
+</body>
+</html>
+"""
+
+# What LinkedIn serves when it does not want to answer -- no <main>, no anchor.
+LINKEDIN_BLOCKED = '<!DOCTYPE html><html><body><h1>Sign in to continue</h1></body></html>'
+
+
+class TestRedirectShortlinks(unittest.TestCase):
+    """Shorteners that answer with a 3xx and a Location header."""
+
+    def test_twitter_shortlink(self):
+        routes = {'t.co/g6VWYYwY12':
+                  redirect('https://github.com/obsidianforensics/unfurl#online-version')}
+
+        with patch_requests_get(routes) as calls:
+            test = Unfurl(remote_lookups=True)
+            test.add_to_queue(data_type='url', key=None, value='https://t.co/g6VWYYwY12')
+            test.parse_queue()
+
+        self.assertTrue(has_node(test, value='/g6VWYYwY12'))
+        self.assertTrue(has_node(test, value='github.com'))
+        self.assertTrue(has_node(test, data_type='url.path.segment', key=1,
+                                 value='obsidianforensics'))
+        self.assertTrue(test.queue.empty())
+
+        self.assertEqual(1, len(calls), msg=f'expected one outbound request, got {calls}')
+
+    def test_lowercase_location_header_is_handled(self):
+        """Real shorteners send "location", not "Location".
+
+        expand_url_via_redirect_header reads r.headers['Location'], which only works
+        because requests uses a case-insensitive mapping. Pin that down.
+        """
+
+        routes = {'t.co/abc': FakeResponse(status_code=301,
+                                           headers={'location': 'https://example.com/target'})}
+
+        with patch_requests_get(routes):
+            test = Unfurl(remote_lookups=True)
+            test.add_to_queue(data_type='url', key=None, value='https://t.co/abc')
+            test.parse_queue()
+
+        self.assertTrue(has_node(test, value='example.com'))
+
+    def test_non_redirect_response_expands_nothing(self):
+        """A 200 (or a 404) is not an expansion, and must not be reported as one."""
+
+        for status_code in (200, 404, 410, 500):
+            with self.subTest(status_code=status_code):
+                routes = {'t.co/abc': FakeResponse(status_code=status_code)}
+
+                with patch_requests_get(routes):
+                    test = Unfurl(remote_lookups=True)
+                    test.add_to_queue(data_type='url', key=None, value='https://t.co/abc')
+                    test.parse_queue()
+
+                self.assertEqual([], expanded_nodes(test))
+
+    def test_all_redirect_status_codes_are_followed(self):
+        for status_code in (301, 302, 303, 307, 308):
+            with self.subTest(status_code=status_code):
+                routes = {'t.co/abc': redirect('https://example.com/target',
+                                               status_code=status_code)}
+
+                with patch_requests_get(routes):
+                    test = Unfurl(remote_lookups=True)
+                    test.add_to_queue(data_type='url', key=None, value='https://t.co/abc')
+                    test.parse_queue()
+
+                self.assertTrue(has_node(test, value='example.com'))
+
+
+class TestLinkedInShortlinks(unittest.TestCase):
+    """LinkedIn serves an interstitial page instead of redirecting."""
 
     def test_linkedin_shortlink(self):
-        """ Test a LinkedIn shortlink; these work a little different from the rest"""
+        routes = {'linkedin.com/slink': FakeResponse(content=LINKEDIN_INTERSTITIAL)}
 
-        test = Unfurl(remote_lookups=True)
-        test.add_to_queue(data_type='url', key=None, value='https://lnkd.in/fDJnJ64')
-        test.parse_queue()
+        with patch_requests_get(routes):
+            test = Unfurl(remote_lookups=True)
+            test.add_to_queue(data_type='url', key=None, value='https://lnkd.in/fDJnJ64')
+            test.parse_queue()
 
-        # Verify key structural elements
         self.assertTrue(has_node(test, value='/fDJnJ64'))
         self.assertTrue(has_node(test, value='thisweekin4n6.com'))
         self.assertTrue(has_node(test, data_type='url.path.segment', key=4))
-
-        # is processing finished
         self.assertTrue(test.queue.empty())
 
-    def test_shortlink_with_no_code(self):
-        """ Test that a path of only slashes isn't "expanded".
+    def test_target_link_is_chosen_over_the_learn_more_link(self):
+        """Both anchors carry the artdeco-button class; only one is the destination."""
 
-        The short code is the path with its slashes stripped, so "///" leaves nothing.
+        routes = {'linkedin.com/slink': FakeResponse(content=LINKEDIN_INTERSTITIAL)}
+
+        with patch_requests_get(routes):
+            test = Unfurl(remote_lookups=True)
+            test.add_to_queue(data_type='url', key=None, value='https://lnkd.in/fDJnJ64')
+            test.parse_queue()
+
+        self.assertTrue(has_node(test, value='thisweekin4n6.com'))
+        self.assertFalse(has_node(test, value='www.linkedin.com'),
+                         msg='expanded to the "learn more" link instead of the target')
+
+    def test_blocked_interstitial_is_handled(self):
+        """A page without the anchor must expand to nothing, not raise.
+
+        Regression test: `soup.select_one(...)` returns None when LinkedIn serves a
+        sign-in wall, changes its markup, or turns a datacenter IP away, and
+        `link.get('href')` used to raise AttributeError on it. run_plugins swallowed the
+        exception, so the symptom was a missing expansion plus a traceback in the log.
+        """
+
+        routes = {'linkedin.com/slink': FakeResponse(content=LINKEDIN_BLOCKED)}
+
+        with self.assertLogs('unfurl.parsers.parse_shortlink', level='WARNING') as logged:
+            with patch_requests_get(routes):
+                test = Unfurl(remote_lookups=True)
+                test.add_to_queue(data_type='url', key=None, value='https://lnkd.in/fDJnJ64')
+                test.parse_queue()
+
+        self.assertEqual([], expanded_nodes(test))
+        self.assertIn('No destination link found', ''.join(logged.output))
+
+    def test_non_200_interstitial_is_handled(self):
+        """LinkedIn answers bots it declines to serve with HTTP 999."""
+
+        for status_code in (999, 403, 404, 429):
+            with self.subTest(status_code=status_code):
+                routes = {'linkedin.com/slink': FakeResponse(status_code=status_code,
+                                                             content=LINKEDIN_BLOCKED)}
+
+                with self.assertLogs('unfurl.parsers.parse_shortlink',
+                                     level='WARNING') as logged:
+                    with patch_requests_get(routes):
+                        test = Unfurl(remote_lookups=True)
+                        test.add_to_queue(data_type='url', key=None,
+                                          value='https://lnkd.in/fDJnJ64')
+                        test.parse_queue()
+
+                self.assertEqual([], expanded_nodes(test))
+                self.assertIn(str(status_code), ''.join(logged.output))
+
+    def test_anchor_without_href_is_handled(self):
+        anchor_without_href = (
+            '<html><body><main><a class="artdeco-button">Continue</a></main></body></html>')
+        routes = {'linkedin.com/slink': FakeResponse(content=anchor_without_href)}
+
+        with self.assertLogs('unfurl.parsers.parse_shortlink', level='WARNING'):
+            with patch_requests_get(routes):
+                test = Unfurl(remote_lookups=True)
+                test.add_to_queue(data_type='url', key=None, value='https://lnkd.in/fDJnJ64')
+                test.parse_queue()
+
+        self.assertEqual([], expanded_nodes(test))
+
+    def test_failure_does_not_raise_into_the_log(self):
+        """The failure path must not produce a traceback.
+
+        run_plugins logs any exception a parser raises, so "it still worked" hides a
+        crash. Assert the parser handled it rather than threw.
+        """
+
+        routes = {'linkedin.com/slink': FakeResponse(content=LINKEDIN_BLOCKED)}
+
+        with self.assertLogs('unfurl', level='WARNING') as logged:
+            with patch_requests_get(routes):
+                test = Unfurl(remote_lookups=True)
+                test.add_to_queue(data_type='url', key=None, value='https://lnkd.in/fDJnJ64')
+                test.parse_queue()
+
+        self.assertFalse(any('AttributeError' in message for message in logged.output),
+                         msg='a blocked page should be handled, not raise AttributeError')
+        self.assertFalse(any('Traceback' in message for message in logged.output))
+
+
+class TestShortlinkGuards(unittest.TestCase):
+    """Cases that must not produce a request at all."""
+
+    def test_shortlink_with_no_code(self):
+        """A path of only slashes leaves no short code.
+
         Requesting the bare base URL would follow the shortener's own front-page
-        redirect and report it as this link's expansion. The guard also means this
-        test makes no network request.
+        redirect and report it as this link's expansion.
         """
 
         for url in ('https://t.co//', 'https://t.co///', 'https://bit.ly//'):
-            test = Unfurl(remote_lookups=True)
-            test.add_to_queue(data_type='url', key=None, value=url)
-            test.parse_queue()
+            with self.subTest(url=url):
+                with patch_requests_get({}) as calls:
+                    test = Unfurl(remote_lookups=True)
+                    test.add_to_queue(data_type='url', key=None, value=url)
+                    test.parse_queue()
 
-            expanded = [n for n in test.nodes.values() if str(n.label).startswith('Expanded URL')]
-            self.assertEqual([], expanded, msg=f'did not expect an expansion for {url}')
-
-    def test_twitter_shortlink(self):
-        """ Test a Twitter shortlink; these use 301 redirects like most shortlinks"""
-
-        test = Unfurl(remote_lookups=True)
-        test.add_to_queue(data_type='url', key=None, value='https://t.co/g6VWYYwY12')
-        test.parse_queue()
-
-        # Verify the shortlink resolved to a github.com URL
-        self.assertTrue(has_node(test, value='/g6VWYYwY12'))
-        self.assertTrue(has_node(test, value='github.com'))
-        self.assertTrue(has_node(test, data_type='url.path.segment', key=1, value='obsidianforensics'))
-
-
-        # is processing finished
-        self.assertTrue(test.queue.empty())
+                self.assertEqual([], expanded_nodes(test),
+                                 msg=f'did not expect an expansion for {url}')
+                self.assertEqual([], calls,
+                                 msg=f'did not expect a network request for {url}')
 
     def test_no_lookups(self):
-        """ Test a shortlink with remote lookups disabled"""
+        """With remote lookups disabled, nothing is expanded and nothing is requested."""
 
-        test = Unfurl()
-        test.remote_lookups = False
-        test.add_to_queue(data_type='url', key=None, value='https://t.co/g6VWYYwY12')
-        test.parse_queue()
+        with patch_requests_get({}) as calls:
+            test = Unfurl(remote_lookups=False)
+            test.add_to_queue(data_type='url', key=None, value='https://t.co/g6VWYYwY12')
+            test.parse_queue()
 
-        # Without remote lookups, the shortlink can't be expanded
         self.assertTrue(has_node(test, value='/g6VWYYwY12'))
         self.assertFalse(has_node(test, value='github.com'))
+        self.assertEqual([], calls)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…ortlink parsing.

- Update `resolve_remote_lookups` to distinguish between `None`, `True`, and `False` for explicit handling of remote lookup behavior.
- Add support for mocking HTTP responses in `unfurl.tests.http_mocks`.
- Implement LinkedIn shortlink parser improvements to handle various interstitial scenarios gracefully.
- Add live and unit tests for LinkedIn and Twitter shortlinks, including error handling and expansion scenarios.
- Update CLI and app interfaces to align remote lookup defaults with the new logic.

- [x] Tests pass
