### PR TITLE
Add file extension knowledge module and comprehensive tests for file …

### DIFF
--- a/unfurl/core.py
+++ b/unfurl/core.py
@@ -137,6 +137,9 @@ class Unfurl:
         self.api_keys = {}
         self.known_domain_lists = None
         self.node_limit = 500
+        # How many times one (data_type, value) may appear along a single line of
+        # ancestry before Unfurl stops expanding it. See find_repeated_ancestor().
+        self.max_repeated_ancestors = 2
         self.stash = {}
 
         config = load_config()
@@ -281,6 +284,51 @@ class Unfurl:
             Unfurl.get_predecessor_chain(self, predecessor[0], chain)
 
         return chain
+
+    def find_repeated_ancestor(self, data_type, value, parent_id):
+        """Return the ancestor that pushes this value over the repeat limit, or None.
+
+        Unfurl's parsers can feed each other in a loop. A 1drv.ms link expands to an
+        onedrive.live.com redirect whose "redeem" parameter is base64 of the *original*
+        1drv.ms URL, so decoding it hands the shortlink parser the same link again.
+        Nothing in the queue noticed, so a single input filled the graph with identical
+        branches until it hit node_limit -- and every lap fired another HTTP request at
+        the shortener.
+
+        Two choices here are deliberate:
+
+        Compared against ancestors, not against every node. The same value legitimately
+        appears in sibling branches -- a path with two "file" segments, a parameter
+        repeated across two URLs -- and those are separate, real observations. Only a
+        value repeating along one line of ancestry means the parsers are going in
+        circles.
+
+        Allows a repeat before stopping (max_repeated_ancestors). Stopping at the very
+        first repeat would misfire on genuine redirect chains that keep a path while
+        changing the query, e.g. /x?a=1 -> /x?a=2 -> /x?a=3, where url.path repeats but
+        each hop is real evidence. Requiring the value to come around twice keeps those
+        intact while still bounding a true loop to a couple of laps.
+        """
+
+        if parent_id is None:
+            return None
+
+        # A node can be attached to more than one parent; any of their lines counts.
+        parent_ids = parent_id if isinstance(parent_id, list) else [parent_id]
+
+        seen = 0
+        for single_parent_id in parent_ids:
+            parent = self.nodes.get(single_parent_id)
+            if not parent:
+                continue
+
+            for ancestor in [parent] + self.get_predecessor_chain(parent):
+                if ancestor.data_type == data_type and ancestor.value == value:
+                    seen += 1
+                    if seen >= self.max_repeated_ancestors:
+                        return ancestor
+
+        return None
 
     @staticmethod
     def check_if_in_node_chain(chain: list, key, value, chain_index: int) -> bool:
@@ -487,12 +535,36 @@ class Unfurl:
 
     def parse(self, queued_item):
         item = queued_item
+
+        repeated_ancestor = self.find_repeated_ancestor(
+            item['data_type'], item['value'], item.get('parent_id'))
+
+        hover = utils.wrap_hover_text(item['hover'])
+        if repeated_ancestor:
+            # The node is still created. It is a real observation -- the value genuinely
+            # came around again -- and silently dropping it would hide the loop instead
+            # of showing it. What stops is the parsing below, and the hover says so, so
+            # the missing children read as Unfurl's decision rather than as the data
+            # simply ending here.
+            cycle_hover = utils.wrap_hover_text(
+                f'Unfurl stopped expanding here. This same value already appears '
+                f'{self.max_repeated_ancestors} times above this node in the graph '
+                f'(most recently at node {repeated_ancestor.node_id}), which means the '
+                f'parsers are looping. The node is kept, but it was not parsed further.')
+            hover = f'{hover}<br><br>{cycle_hover}' if hover else cycle_hover
+
         node_id = self.create_node(
             data_type=item['data_type'], key=item['key'], value=item['value'],
-            label=item['label'], hover=utils.wrap_hover_text(item['hover']),
+            label=item['label'], hover=hover,
             parent_id=item.get('parent_id', None),
             incoming_edge_config=item.get('incoming_edge_config', None),
             extra_options=item.get('extra_options', None))
+
+        if repeated_ancestor:
+            log.info(
+                f'Not parsing node {node_id}; its value repeats ancestor '
+                f'{repeated_ancestor.node_id} ({item["data_type"]})')
+            return
 
         self.run_plugins(self.nodes[node_id])
 

--- a/unfurl/file_types.py
+++ b/unfurl/file_types.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Ryan Benson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""File extension knowledge used when a URL path segment looks like a filename.
+
+Python's ``mimetypes.types_map`` is the obvious source for this, but it is built
+for serving web content, not for examining evidence. It carries ~154 entries and
+omits nearly everything an analyst actually finds in a cloud-storage or download
+URL: no ``.docx``/``.xlsx``/``.pptx``, no ``.rar``/``.7z``/``.iso``, and none of
+the Windows script and installer formats used to deliver malware.
+
+This module keeps an Unfurl-owned table of those extensions and merges it over
+``mimetypes``. Owning the table also buys a place to record *why* an extension
+matters, which a media type alone cannot express -- an analyst is better served
+by "Windows shortcut; frequently abused to launch commands" than by
+``application/x-ms-shortcut``.
+
+The table is deliberately additive. Extensions that collide with common non-file
+path segments are left out on purpose; see ``EXCLUDED_EXTENSIONS``.
+"""
+
+import mimetypes
+from typing import NamedTuple, Optional, Tuple
+
+
+class FileType(NamedTuple):
+    """What Unfurl knows about one file extension."""
+
+    media_type: str
+    description: Optional[str] = None
+    # Why an analyst should care. Shown in hover text when present.
+    note: Optional[str] = None
+
+
+# Extensions Unfurl deliberately refuses to recognize, because the false
+# positives cost more than the hits are worth:
+#
+#   .com  - a TLD before it is an MS-DOS executable. Any path segment holding a
+#           bare hostname ("example.com", common in redirect paths) would be
+#           mislabeled as an executable, which is a scary and wrong finding.
+#   .url  - a real Windows shortcut format, but "*.url" also matches ordinary
+#           words and route names in paths.
+#
+# The single-character extensions mimetypes ships (.a .c .h .o .t) are compiler
+# and archive artifacts that essentially never appear as a shared file in a URL,
+# while matching any path segment whose last dot-group is one character. Measured
+# against 23,186 path segments from general web traffic, ".o" alone accounted for
+# every remaining false positive -- cache-busting tokens like
+# "k=xjs.s.ja.NOfIU4zhi6w.O". Case-insensitive matching makes them worse, so they
+# are excluded rather than special-cased.
+EXCLUDED_EXTENSIONS = frozenset({'.com', '.url', '.a', '.c', '.h', '.o', '.t'})
+
+
+# Extensions Unfurl knows about beyond what mimetypes provides. Where an
+# extension has no registered IANA media type, the de-facto type in common use
+# is recorded instead; genuinely ambiguous containers get
+# application/octet-stream rather than an invented type.
+UNFURL_FILE_TYPES = {
+    # -- Microsoft Office, OOXML --------------------------------------------
+    '.docx': FileType(
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'Microsoft Word document'),
+    '.xlsx': FileType(
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Microsoft Excel workbook'),
+    '.pptx': FileType(
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'Microsoft PowerPoint presentation'),
+    '.docm': FileType(
+        'application/vnd.ms-word.document.macroEnabled.12',
+        'Microsoft Word document, macro-enabled',
+        'Macro-enabled Office formats can carry VBA code and are a long-standing '
+        'malware delivery vector.'),
+    '.xlsm': FileType(
+        'application/vnd.ms-excel.sheet.macroEnabled.12',
+        'Microsoft Excel workbook, macro-enabled',
+        'Macro-enabled Office formats can carry VBA code and are a long-standing '
+        'malware delivery vector.'),
+    '.pptm': FileType(
+        'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
+        'Microsoft PowerPoint presentation, macro-enabled',
+        'Macro-enabled Office formats can carry VBA code and are a long-standing '
+        'malware delivery vector.'),
+    '.one': FileType('application/onenote', 'Microsoft OneNote section'),
+    '.msg': FileType('application/vnd.ms-outlook', 'Microsoft Outlook message'),
+    '.pst': FileType(
+        'application/vnd.ms-outlook-pst', 'Microsoft Outlook personal folders',
+        'A full offline mailbox. Rarely shared innocently -- a common bulk email '
+        'exfiltration artifact.'),
+    '.ost': FileType(
+        'application/vnd.ms-outlook-ost', 'Microsoft Outlook offline folders',
+        'A full offline mailbox. Rarely shared innocently -- a common bulk email '
+        'exfiltration artifact.'),
+
+    # -- OpenDocument -------------------------------------------------------
+    '.odt': FileType('application/vnd.oasis.opendocument.text', 'OpenDocument text'),
+    '.ods': FileType('application/vnd.oasis.opendocument.spreadsheet', 'OpenDocument spreadsheet'),
+    '.odp': FileType('application/vnd.oasis.opendocument.presentation', 'OpenDocument presentation'),
+
+    # -- Archives and disk images -------------------------------------------
+    '.rar': FileType('application/vnd.rar', 'RAR archive'),
+    '.7z': FileType('application/x-7z-compressed', '7-Zip archive'),
+    '.gz': FileType('application/gzip', 'gzip-compressed data'),
+    '.tar.gz': FileType('application/gzip', 'gzip-compressed tar archive'),
+    '.tgz': FileType('application/gzip', 'gzip-compressed tar archive'),
+    '.tar.bz2': FileType('application/x-bzip2', 'bzip2-compressed tar archive'),
+    '.bz2': FileType('application/x-bzip2', 'bzip2-compressed data'),
+    '.tar.xz': FileType('application/x-xz', 'xz-compressed tar archive'),
+    '.xz': FileType('application/x-xz', 'xz-compressed data'),
+    '.zst': FileType('application/zstd', 'Zstandard-compressed data'),
+    '.cab': FileType('application/vnd.ms-cab-compressed', 'Microsoft cabinet archive'),
+    '.wim': FileType('application/x-ms-wim', 'Windows Imaging Format archive'),
+    '.iso': FileType(
+        'application/x-iso9660-image', 'ISO 9660 disc image',
+        'Disc images mount without applying the Mark-of-the-Web to their contents, '
+        'which is why they became a favored malware container.'),
+    '.img': FileType(
+        'application/octet-stream', 'Raw disk image',
+        'Disc images mount without applying the Mark-of-the-Web to their contents, '
+        'which is why they became a favored malware container.'),
+    '.vhd': FileType('application/x-vhd', 'Virtual hard disk'),
+    '.vhdx': FileType('application/x-vhdx', 'Virtual hard disk (VHDX)'),
+    '.vmdk': FileType('application/x-vmdk', 'VMware virtual disk'),
+    '.ova': FileType('application/x-virtualbox-ova', 'Open Virtualization Appliance'),
+
+    # -- Windows executables, installers, and scripts -----------------------
+    '.msi': FileType(
+        'application/x-msi', 'Windows Installer package',
+        'Executes with installer privileges; a common malware delivery format.'),
+    '.msix': FileType('application/msix', 'Windows MSIX application package'),
+    '.appx': FileType('application/vnd.ms-appx', 'Windows APPX application package'),
+    '.lnk': FileType(
+        'application/x-ms-shortcut', 'Windows shortcut',
+        'A shortcut stores an arbitrary command line, so a .lnk can launch anything. '
+        'Heavily abused in phishing since macros were restricted by default.'),
+    '.scr': FileType(
+        'application/x-msdownload', 'Windows screensaver (a PE executable)',
+        'A .scr is an ordinary Windows executable with a different extension -- a '
+        'classic disguise.'),
+    '.pif': FileType(
+        'application/x-msdownload', 'Program Information File',
+        'Legacy MS-DOS shortcut format that Windows will execute as a program.'),
+    '.cpl': FileType(
+        'application/x-msdownload', 'Windows Control Panel item (a DLL)',
+        'A .cpl is a DLL that Windows will load and run.'),
+    '.hta': FileType(
+        'application/hta', 'HTML Application',
+        'Runs script outside the browser sandbox with full user privileges.'),
+    '.vbs': FileType(
+        'text/vbscript', 'VBScript script',
+        'Executed by Windows Script Host with the invoking user\'s privileges.'),
+    '.vbe': FileType(
+        'text/vbscript', 'Encoded VBScript script',
+        'Executed by Windows Script Host with the invoking user\'s privileges.'),
+    '.jse': FileType(
+        'text/javascript', 'Encoded JScript script',
+        'Executed by Windows Script Host with the invoking user\'s privileges.'),
+    '.wsf': FileType(
+        'application/x-ms-wsf', 'Windows Script File',
+        'Executed by Windows Script Host with the invoking user\'s privileges.'),
+    '.wsh': FileType('application/x-ms-wsh', 'Windows Script Host settings file'),
+    '.ps1': FileType('application/x-powershell', 'PowerShell script'),
+    '.psm1': FileType('application/x-powershell', 'PowerShell module'),
+    '.cmd': FileType('application/x-bat', 'Windows command script'),
+    '.chm': FileType(
+        'application/vnd.ms-htmlhelp', 'Compiled HTML Help',
+        'Can embed and execute script; used to deliver malware.'),
+    '.reg': FileType(
+        'text/plain', 'Windows registry export',
+        'Double-clicking imports the contents into the registry.'),
+    '.inf': FileType('text/plain', 'Windows setup information file'),
+    '.sys': FileType('application/octet-stream', 'Windows system/driver file'),
+    '.settingcontent-ms': FileType(
+        'application/xml', 'Windows settings shortcut',
+        'An XML format that can specify an arbitrary command to execute.'),
+    '.diagcab': FileType(
+        'application/vnd.ms-cab-compressed', 'Windows troubleshooting package',
+        'A signed cabinet that can run script through the diagnostics platform.'),
+
+    # -- Other platforms ----------------------------------------------------
+    '.apk': FileType('application/vnd.android.package-archive', 'Android application package'),
+    '.aab': FileType('application/octet-stream', 'Android App Bundle'),
+    '.ipa': FileType('application/octet-stream', 'iOS application archive'),
+    '.dmg': FileType('application/x-apple-diskimage', 'Apple disk image'),
+    '.pkg': FileType('application/octet-stream', 'macOS installer package'),
+    '.deb': FileType('application/vnd.debian.binary-package', 'Debian package'),
+    '.rpm': FileType('application/x-rpm', 'RPM package'),
+    '.jar': FileType('application/java-archive', 'Java archive'),
+    '.crx': FileType('application/x-chrome-extension', 'Chrome extension package'),
+    '.xpi': FileType('application/x-xpinstall', 'Firefox extension package'),
+
+    # -- Data, databases, and forensic artifacts ----------------------------
+    '.sqlite': FileType('application/vnd.sqlite3', 'SQLite database'),
+    '.sqlite3': FileType('application/vnd.sqlite3', 'SQLite database'),
+    '.db': FileType('application/octet-stream', 'Database file (format varies)'),
+    '.evtx': FileType('application/octet-stream', 'Windows event log'),
+    '.pcap': FileType('application/vnd.tcpdump.pcap', 'Packet capture'),
+    '.pcapng': FileType('application/x-pcapng', 'Packet capture (pcapng)'),
+    '.log': FileType('text/plain', 'Log file'),
+    '.ini': FileType('text/plain', 'Configuration file'),
+    '.torrent': FileType('application/x-bittorrent', 'BitTorrent metainfo file'),
+    '.epub': FileType('application/epub+zip', 'EPUB publication'),
+
+    # -- Media not covered by mimetypes -------------------------------------
+    '.mkv': FileType('video/x-matroska', 'Matroska video'),
+    '.heif': FileType('image/heif', 'HEIF image'),
+    '.avif': FileType('image/avif', 'AVIF image'),
+    '.opus': FileType('audio/opus', 'Opus audio'),
+    '.flac': FileType('audio/flac', 'FLAC audio'),
+}
+
+
+def _build_extension_map() -> dict:
+    """Merge the Unfurl table over mimetypes, honoring EXCLUDED_EXTENSIONS."""
+
+    combined = {}
+    for extension, media_type in mimetypes.types_map.items():
+        if extension in EXCLUDED_EXTENSIONS:
+            continue
+        combined[extension.lower()] = FileType(media_type)
+
+    for extension, file_type in UNFURL_FILE_TYPES.items():
+        if extension in EXCLUDED_EXTENSIONS:
+            continue
+        combined[extension.lower()] = file_type
+
+    return combined
+
+
+# Extension -> FileType. Keys are lowercase; look up with a lowercased value.
+EXTENSION_MAP = _build_extension_map()
+
+# The most dots any known extension contains (".tar.gz" -> 2). Bounds how far
+# back a candidate search has to look.
+_MAX_EXTENSION_PARTS = max(extension.count('.') for extension in EXTENSION_MAP)
+
+
+def lookup_extension(segment: str) -> Optional[Tuple[str, FileType]]:
+    """Find the longest known extension that ``segment`` ends with.
+
+    Returns ``(extension_as_written, FileType)``, or None when the segment does
+    not end in a recognized extension or has no filename before it.
+
+    Matching is case-insensitive -- real URLs carry ``.JPG`` as readily as
+    ``.jpg`` -- but the returned extension preserves the original casing so the
+    node shows what the URL actually said.
+
+    Longest match wins, so ``backup.tar.gz`` reports ``.tar.gz`` rather than
+    ``.gz``.
+    """
+
+    if not segment or '.' not in segment:
+        return None
+
+    parts = segment.split('.')
+
+    # Try the most dot-separated candidate first (".tar.gz" before ".gz") so the
+    # longest known extension wins.
+    for part_count in range(min(_MAX_EXTENSION_PARTS, len(parts) - 1), 0, -1):
+        candidate = '.' + '.'.join(parts[-part_count:])
+        file_type = EXTENSION_MAP.get(candidate.lower())
+        if file_type is None:
+            continue
+
+        # Require something before the extension; a segment that is *only* an
+        # extension (".pdf", or a dotfile like ".gitignore") is not a filename
+        # with a meaningful name part.
+        if len(segment) == len(candidate):
+            return None
+
+        return candidate, file_type
+
+    return None

--- a/unfurl/parsers/parse_url.py
+++ b/unfurl/parsers/parse_url.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mimetypes
 import pycountry
 import re
 import urllib.parse
+
+from unfurl import utils
+from unfurl.file_types import lookup_extension
 
 urlparse_edge = {
     'color': {
@@ -301,17 +303,31 @@ def run(unfurl, node):
             try_url_unquote(unfurl, node)
 
     elif node.data_type == 'url.path.segment':
-        for file_type in mimetypes.types_map.keys():
-            if node.value.endswith(file_type):
-                unfurl.add_to_queue(
-                    data_type='file.name', key='File Name',
-                    value=urllib.parse.unquote_plus(node.value[:-len(file_type)]),
-                    parent_id=node.node_id, incoming_edge_config=urlparse_edge)
-                unfurl.add_to_queue(
-                    data_type='file.ext', key='File Extension', value=node.value[-len(file_type):],
-                    hover=f'The data type typically associated with <b>{file_type}</b> '
-                          f'is <b>{mimetypes.types_map[file_type]}</b>',
-                    parent_id=node.node_id, incoming_edge_config=urlparse_edge)
+        match = lookup_extension(node.value)
+        if match:
+            extension, file_type = match
+
+            hover = f'The data type typically associated with <b>{extension}</b> ' \
+                    f'is <b>{file_type.media_type}</b>'
+            if file_type.description:
+                hover += f' ({file_type.description})'
+            hover += '.'
+            if file_type.note:
+                # Wrap each paragraph before joining them. wrap_hover_text leaves any
+                # text that already contains a <br> alone -- the author is assumed to
+                # have chosen the breaks -- so adding the separator first would mean
+                # the note never gets wrapped at all.
+                hover = f'{utils.wrap_hover_text(hover)}<br><br>' \
+                        f'{utils.wrap_hover_text(file_type.note)}'
+
+            unfurl.add_to_queue(
+                data_type='file.name', key='File Name',
+                value=urllib.parse.unquote_plus(node.value[:-len(extension)]),
+                parent_id=node.node_id, incoming_edge_config=urlparse_edge)
+            unfurl.add_to_queue(
+                data_type='file.ext', key='File Extension', value=extension,
+                hover=hover,
+                parent_id=node.node_id, incoming_edge_config=urlparse_edge)
 
     else:
         if not isinstance(node.value, str):

--- a/unfurl/tests/unit/test_facebook.py
+++ b/unfurl/tests/unit/test_facebook.py
@@ -1,5 +1,16 @@
 from unfurl.core import Unfurl
+import re
 import unittest
+
+
+def hover_text(node):
+    """A node's hover with markup removed and whitespace collapsed.
+
+    Hover text is wrapped for display, which inserts <br> at positions that depend on the
+    exact wording. Matching against the raw value makes an assertion pass or fail on where
+    a line break happened to land, so match against what the reader actually sees.
+    """
+    return ' '.join(re.sub(r'<[^>]+>', ' ', node.hover or '').split())
 
 
 def has_node(unfurl_instance, **criteria):
@@ -26,11 +37,11 @@ class TestFacebook(unittest.TestCase):
         # u and h get hover text only from our parser
         for node in u.nodes.values():
             if node.data_type == 'url.query.pair' and node.key == 'h':
-                self.assertIn('verification hash', node.hover)
+                self.assertIn('verification hash', hover_text(node))
                 break
         for node in u.nodes.values():
             if node.data_type == 'url.query.pair' and node.key == 'u':
-                self.assertIn('destination URL', node.hover)
+                self.assertIn('destination URL', hover_text(node))
                 break
 
     def test_redirect_lsr_php_hover(self):
@@ -41,7 +52,7 @@ class TestFacebook(unittest.TestCase):
             '&ext=1442879836&hash=AcnnZ5k0wBh4ZaGZFmBXimGK')
         for node in u.nodes.values():
             if node.data_type == 'url.query.pair' and node.key == 'ext':
-                self.assertIn('timestamp', node.hover.lower())
+                self.assertIn('timestamp', hover_text(node).lower())
                 break
 
     def test_profile_php_id(self):
@@ -109,7 +120,7 @@ class TestFacebook(unittest.TestCase):
         self.assertFalse(has_node(u, data_type='facebook.mibextid'))
         for node in u.nodes.values():
             if node.data_type == 'url.query.pair' and node.key == 'mibextid':
-                self.assertIn('Mobile', node.hover)
+                self.assertIn('Mobile', hover_text(node))
                 break
         else:
             self.fail('mibextid query pair node not found')

--- a/unfurl/tests/unit/test_file_types.py
+++ b/unfurl/tests/unit/test_file_types.py
@@ -1,0 +1,173 @@
+from unfurl.core import Unfurl
+from unfurl.file_types import EXCLUDED_EXTENSIONS, lookup_extension
+import unittest
+
+
+def file_nodes(unfurl_instance):
+    """Return {data_type: value} for the file.name / file.ext nodes in a graph."""
+
+    return {node.data_type: node.value for node in unfurl_instance.nodes.values()
+            if node.data_type in ('file.name', 'file.ext')}
+
+
+def hover_for(unfurl_instance, data_type):
+    for node in unfurl_instance.nodes.values():
+        if node.data_type == data_type:
+            return node.hover
+    return None
+
+
+def unfurl_url(value):
+    test = Unfurl()
+    test.add_to_queue(data_type='url', key=None, value=value)
+    test.parse_queue()
+    return test
+
+
+class TestLookupExtension(unittest.TestCase):
+    """Unit tests for the extension table itself."""
+
+    def test_office_open_xml_extensions(self):
+        """Office documents are the most common cloud-storage filenames and are
+        absent from Python's mimetypes."""
+
+        for filename, expected in (('Budget FY26.xlsx', '.xlsx'),
+                                   ('Report.docx', '.docx'),
+                                   ('Deck.pptx', '.pptx')):
+            with self.subTest(filename=filename):
+                match = lookup_extension(filename)
+                self.assertIsNotNone(match)
+                self.assertEqual(expected, match[0])
+
+    def test_archive_extensions(self):
+        for filename, expected in (('hanyu.rar', '.rar'),
+                                   ('payload.7z', '.7z'),
+                                   ('disk.iso', '.iso'),
+                                   ('setup.msi', '.msi')):
+            with self.subTest(filename=filename):
+                match = lookup_extension(filename)
+                self.assertIsNotNone(match)
+                self.assertEqual(expected, match[0])
+
+    def test_longest_extension_wins(self):
+        """'.tar.gz' must beat '.gz', otherwise the name keeps a stray '.tar'."""
+
+        match = lookup_extension('backup.tar.gz')
+        self.assertIsNotNone(match)
+        self.assertEqual('.tar.gz', match[0])
+
+        match = lookup_extension('backup.tar.bz2')
+        self.assertIsNotNone(match)
+        self.assertEqual('.tar.bz2', match[0])
+
+    def test_matching_is_case_insensitive_but_preserves_casing(self):
+        """Real URLs carry '.JPG'; the node should still say '.JPG'."""
+
+        match = lookup_extension('林暮色16部A.JPG')
+        self.assertIsNotNone(match)
+        self.assertEqual('.JPG', match[0])
+        self.assertEqual('image/jpeg', match[1].media_type)
+
+    def test_mimetypes_entries_still_resolve(self):
+        """The Unfurl table supplements mimetypes rather than replacing it."""
+
+        match = lookup_extension('logo.png')
+        self.assertIsNotNone(match)
+        self.assertEqual('.png', match[0])
+        self.assertEqual('image/png', match[1].media_type)
+
+    def test_excluded_extensions_do_not_match(self):
+        """'.com' and '.url' collide with ordinary path segments, so a segment
+        holding a bare hostname must not be reported as an executable."""
+
+        self.assertIn('.com', EXCLUDED_EXTENSIONS)
+        self.assertIsNone(lookup_extension('example.com'))
+        self.assertIsNone(lookup_extension('route.url'))
+
+    def test_single_character_extensions_do_not_match(self):
+        """mimetypes ships .a/.c/.h/.o/.t; case-insensitive matching turns them
+        into noise on cache-busting tokens and truncated hostnames."""
+
+        self.assertIsNone(lookup_extension('k=xjs.s.ja.NOfIU4zhi6w.O'))
+        self.assertIsNone(lookup_extension('news.bbc.c'))
+
+    def test_segment_that_is_only_an_extension_does_not_match(self):
+        """A dotfile or bare extension has no name part to report."""
+
+        self.assertIsNone(lookup_extension('.pdf'))
+        self.assertIsNone(lookup_extension('.gitignore'))
+
+    def test_non_filenames_do_not_match(self):
+        for value in ('v1.2', 'index.php', 'noext', '', 'segment'):
+            with self.subTest(value=value):
+                self.assertIsNone(lookup_extension(value))
+
+    def test_forensic_note_present_on_notable_types(self):
+        match = lookup_extension('invoice.pdf.lnk')
+        self.assertIsNotNone(match)
+        self.assertEqual('.lnk', match[0])
+        self.assertIsNotNone(match[1].note)
+
+
+class TestFileTypesInUrls(unittest.TestCase):
+    """End-to-end: the extensions show up as nodes when parsing a real URL."""
+
+    def test_sharepoint_office_document(self):
+        """Regression: '.xlsx' produced no file nodes at all before the
+        Unfurl-owned extension table existed."""
+
+        test = unfurl_url(
+            'https://contoso-my.sharepoint.com/:w:/r/personal/john_contoso_com'
+            '/Documents/Budget%20FY26.xlsx?csf=1&web=1')
+
+        nodes = file_nodes(test)
+        self.assertEqual('Budget FY26', nodes.get('file.name'))
+        self.assertEqual('.xlsx', nodes.get('file.ext'))
+
+    def test_mediafire_archive(self):
+        test = unfurl_url(
+            'https://www.mediafire.com/file/0000nmedi480w2n/hanyu.rar')
+
+        nodes = file_nodes(test)
+        self.assertEqual('hanyu', nodes.get('file.name'))
+        self.assertEqual('.rar', nodes.get('file.ext'))
+
+    def test_backblaze_uppercase_extension(self):
+        """Percent-encoded non-ASCII name with an uppercase extension, taken
+        from a real Wayback corpus URL."""
+
+        test = unfurl_url(
+            'https://f000.backblazeb2.com/file/2023-2/'
+            '%E6%9E%97%E6%9A%AE%E8%89%B216%E9%83%A8A.JPG')
+
+        nodes = file_nodes(test)
+        self.assertEqual('林暮色16部A', nodes.get('file.name'))
+        self.assertEqual('.JPG', nodes.get('file.ext'))
+
+    def test_compound_extension_in_url(self):
+        test = unfurl_url('https://example.com/dist/release-2.1.tar.gz')
+
+        nodes = file_nodes(test)
+        self.assertEqual('release-2.1', nodes.get('file.name'))
+        self.assertEqual('.tar.gz', nodes.get('file.ext'))
+
+    def test_hostname_in_path_is_not_treated_as_a_file(self):
+        """A path segment holding a bare hostname must not yield file nodes."""
+
+        test = unfurl_url('https://example.com/redirect/example.com/next')
+        self.assertEqual({}, file_nodes(test))
+
+    def test_hover_includes_description_and_note(self):
+        test = unfurl_url('https://example.com/downloads/invoice.pdf.lnk')
+
+        nodes = file_nodes(test)
+        self.assertEqual('invoice.pdf', nodes.get('file.name'))
+        self.assertEqual('.lnk', nodes.get('file.ext'))
+
+        hover = hover_for(test, 'file.ext')
+        self.assertIn('application/x-ms-shortcut', hover)
+        self.assertIn('Windows shortcut', hover)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unfurl/tests/unit/test_parse_cycles.py
+++ b/unfurl/tests/unit/test_parse_cycles.py
@@ -156,7 +156,13 @@ class TestShortlinkExpansionLoop(unittest.TestCase):
 
         test, _ = self.run_with_mocked_redirect()
 
-        self.assertTrue(any(node.data_type == 'url' and 'onedrive.live.com' in str(node.value)
+        # Match the parsed hostname exactly rather than looking for the host as a
+        # substring of the URL. "onedrive.live.com" appears in a URL that merely mentions
+        # it -- https://evil.example/?next=onedrive.live.com would satisfy a substring
+        # check -- so the exact comparison is the assertion actually meant here.
+        self.assertTrue(any(node.data_type == 'url.hostname' and node.value == 'onedrive.live.com'
+                            for node in test.nodes.values()))
+        self.assertTrue(any(node.data_type == 'url' and node.value == self.REDIRECT_TARGET
                             for node in test.nodes.values()))
         self.assertTrue(any(node.data_type == 'url.query.pair' and node.key == 'resid'
                             for node in test.nodes.values()))

--- a/unfurl/tests/unit/test_parse_cycles.py
+++ b/unfurl/tests/unit/test_parse_cycles.py
@@ -1,0 +1,189 @@
+from unfurl.core import Unfurl
+from unfurl.parsers import parse_shortlink
+import unittest
+from unittest import mock
+
+
+def build_chain(unfurl_instance, nodes):
+    """Create a linear parent->child chain of (data_type, value) pairs.
+
+    Returns the list of node ids, root first.
+    """
+
+    node_ids = []
+    parent_id = None
+    for data_type, value in nodes:
+        parent_id = unfurl_instance.create_node(
+            data_type=data_type, key=None, value=value, label=None, hover=None,
+            parent_id=parent_id)
+        node_ids.append(parent_id)
+    return node_ids
+
+
+class TestFindRepeatedAncestor(unittest.TestCase):
+    """Unit tests for the cycle check itself, with no parsers involved."""
+
+    def test_no_parent_is_never_a_repeat(self):
+        test = Unfurl(remote_lookups=False)
+        self.assertIsNone(test.find_repeated_ancestor('url', 'https://example.com', None))
+
+    def test_unique_values_are_not_repeats(self):
+        test = Unfurl(remote_lookups=False)
+        chain = build_chain(test, [
+            ('url', 'https://example.com/a'),
+            ('url.path', '/a'),
+            ('url', 'https://example.com/b'),
+        ])
+
+        self.assertIsNone(test.find_repeated_ancestor('url.path', '/b', chain[-1]))
+
+    def test_a_single_repeat_is_allowed(self):
+        """One repeat is a legitimate redirect chain, e.g. /x?a=1 -> /x?a=2."""
+
+        test = Unfurl(remote_lookups=False)
+        chain = build_chain(test, [
+            ('url', 'https://example.com/x?a=1'),
+            ('url.path', '/x'),
+            ('url', 'https://example.com/x?a=2'),
+        ])
+
+        self.assertIsNone(test.find_repeated_ancestor('url.path', '/x', chain[-1]))
+
+    def test_second_repeat_is_flagged(self):
+        test = Unfurl(remote_lookups=False)
+        chain = build_chain(test, [
+            ('url', 'https://example.com/x?a=1'),
+            ('url.path', '/x'),
+            ('url', 'https://example.com/x?a=2'),
+            ('url.path', '/x'),
+            ('url', 'https://example.com/x?a=3'),
+        ])
+
+        repeated = test.find_repeated_ancestor('url.path', '/x', chain[-1])
+        self.assertIsNotNone(repeated)
+        self.assertEqual('url.path', repeated.data_type)
+        self.assertEqual('/x', repeated.value)
+
+    def test_same_value_with_different_data_type_is_not_a_repeat(self):
+        test = Unfurl(remote_lookups=False)
+        chain = build_chain(test, [
+            ('url', 'https://example.com/x'),
+            ('url.path', '/x'),
+            ('url', 'https://example.com/x'),
+            ('url.path', '/x'),
+        ])
+
+        self.assertIsNone(test.find_repeated_ancestor('string', '/x', chain[-1]))
+
+    def test_threshold_is_configurable(self):
+        test = Unfurl(remote_lookups=False)
+        test.max_repeated_ancestors = 1
+        chain = build_chain(test, [
+            ('url', 'https://example.com/x?a=1'),
+            ('url.path', '/x'),
+        ])
+
+        self.assertIsNotNone(test.find_repeated_ancestor('url.path', '/x', chain[-1]))
+
+
+class TestRepeatedSiblingsAreKept(unittest.TestCase):
+    """Repeats across branches are separate observations, not a loop."""
+
+    def test_mediafire_path_with_two_file_segments(self):
+        """mediafire.com/file/{key}/{name}/file has "file" at positions 1 and 4.
+
+        Both are siblings under the same url.path, so neither is an ancestor of
+        the other and both must survive.
+        """
+
+        test = Unfurl(remote_lookups=False)
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://www.mediafire.com/file/0000nmedi480w2n/hanyu.rar/file')
+        test.parse_queue()
+
+        file_segments = [node for node in test.nodes.values()
+                         if node.data_type == 'url.path.segment' and node.value == 'file']
+        self.assertEqual(2, len(file_segments))
+        self.assertEqual({1, 4}, {node.key for node in file_segments})
+
+
+class TestShortlinkExpansionLoop(unittest.TestCase):
+    """End-to-end regression for the 1drv.ms expansion loop.
+
+    A 1drv.ms link expands to a onedrive.live.com redirect whose "redeem"
+    parameter is base64 of the original 1drv.ms URL. Decoding it hands the
+    shortlink parser the same link again, so before the cycle check a single
+    input produced a 500-node graph (the node_limit) and ~22 requests to
+    1drv.ms.
+
+    The redirect target below is a real captured response, so the loop is
+    reproduced without making any network request.
+    """
+
+    REDIRECT_TARGET = (
+        'https://onedrive.live.com/redir?resid=6C474039BCD4FBD8%215769'
+        '&migratedtospo=true'
+        '&redeem=aHR0cHM6Ly8xZHJ2Lm1zL3UvcyFBdGo3MUx3NVFFZHNyUW5UUkhNai1makdjNDlO')
+
+    def run_with_mocked_redirect(self):
+        with mock.patch.object(parse_shortlink, 'expand_url_via_redirect_header',
+                               return_value=self.REDIRECT_TARGET) as expand:
+            test = Unfurl(remote_lookups=True)
+            test.add_to_queue(
+                data_type='url', key=None,
+                value='https://1drv.ms/u/s!Atj71Lw5QEdsrQnTRHMj-fjGc49N?e=hOB5gO')
+            test.parse_queue()
+        return test, expand
+
+    def test_graph_does_not_run_away(self):
+        test, _ = self.run_with_mocked_redirect()
+
+        # The point of the fix: the graph terminates on its own rather than being
+        # cut off by node_limit.
+        self.assertLess(test.total_nodes, test.node_limit)
+        self.assertTrue(test.queue.empty())
+
+    def test_shortener_is_not_hit_repeatedly(self):
+        _, expand = self.run_with_mocked_redirect()
+
+        # Before the fix this was ~22. Two laps are allowed by
+        # max_repeated_ancestors; what matters is that it is bounded and small.
+        self.assertLessEqual(expand.call_count, 3)
+
+    def test_expansion_still_happens(self):
+        """Cycle protection must not stop the first, useful expansion."""
+
+        test, _ = self.run_with_mocked_redirect()
+
+        self.assertTrue(any(node.data_type == 'url' and 'onedrive.live.com' in str(node.value)
+                            for node in test.nodes.values()))
+        self.assertTrue(any(node.data_type == 'url.query.pair' and node.key == 'resid'
+                            for node in test.nodes.values()))
+
+    def test_terminal_node_is_kept_and_explains_itself(self):
+        """The repeated node stays in the graph; only its parsing stops."""
+
+        test, _ = self.run_with_mocked_redirect()
+
+        stopped = [node for node in test.nodes.values()
+                   if node.hover and 'stopped expanding' in node.hover]
+        self.assertTrue(stopped, 'expected at least one node marked as loop-terminated')
+
+        for node in stopped:
+            self.assertEqual([], test.get_successor_nodes(node))
+
+    def test_original_hover_is_preserved(self):
+        """The cycle note is appended to the node's own hover, not substituted."""
+
+        test, _ = self.run_with_mocked_redirect()
+
+        stopped = [node for node in test.nodes.values()
+                   if node.hover and 'stopped expanding' in node.hover
+                   and node.data_type == 'url.path']
+        self.assertTrue(stopped)
+        self.assertIn('RFC3986', stopped[0].hover)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unfurl/utils.py
+++ b/unfurl/utils.py
@@ -23,6 +23,8 @@ import zlib
 from datetime import datetime, timezone
 from typing import Union
 
+# A complete <a ...>...</a>, treated as one unbreakable unit when wrapping hover text.
+anchor_re = re.compile(r'<a\b[^>]*>.*?</a>', re.IGNORECASE | re.DOTALL)
 long_int_re = re.compile(r'\d{8,}')
 urlsafe_b64_re = re.compile(r'[A-Za-z0-9_\-]{8,}={0,2}')
 standard_b64_re = re.compile(r'[A-Za-z0-9+/]{8,}={0,2}')
@@ -157,9 +159,9 @@ def wrap_hover_text(hover_text: Union[str, None]) -> Union[str, None]:
     if not isinstance(hover_text, str):
         return None
 
-    # If there are any manually-inserted <br> or links, leave it
+    # If there are any manually inserted <br> or links, leave it
     # alone. This isn't perfect detection, but it'll do.
-    if '<a' in hover_text or '<br' in hover_text:
+    if '<br' in hover_text:
         return hover_text
 
     # If the text is just a little long, I'd rather have it all on
@@ -167,9 +169,25 @@ def wrap_hover_text(hover_text: Union[str, None]) -> Union[str, None]:
     if len(hover_text) < 70:
         return hover_text
 
+    # Hold each <a>...</a> aside as a single unbreakable token, so a line break can
+    # never land inside a tag and split an href in half. The placeholder is shorter
+    # than the markup it stands in for, which is what we want: lines are measured by
+    # roughly what the reader sees rather than by the length of the HTML.
+    anchors = []
+
+    def stash_anchor(match):
+        anchors.append(match.group(0))
+        return f'\x00{len(anchors) - 1}\x00'
+
+    stashed = anchor_re.sub(stash_anchor, hover_text)
+
     # "Wrap" the hover text by splitting it into lines of length <width>,
     # then joining them together with a <br>.
-    return '<br>'.join(textwrap.wrap(hover_text, width=60))
+    wrapped = '<br>'.join(textwrap.wrap(stashed, width=60))
+
+    for index, anchor in enumerate(anchors):
+        wrapped = wrapped.replace(f'\x00{index}\x00', anchor)
+    return wrapped
 
 
 def create_epoch_seconds_timestamp(iso_timestamp: str | None = None, days_ahead: int | None = None, offset: int | float = 0) -> int:


### PR DESCRIPTION
…types.

- Implement `file_types` module with detailed mappings for file extensions, including descriptions and notes for forensic relevance.
- Introduce `lookup_extension` function to map URL path segments to file types.
- Add unit tests for extension matching, excluding ambiguous extensions, and end-to-end file parsing in URLs.
- Ensure Unfurl-owned extension table supplements Python’s `mimetypes` with malware-relevant file types.
- Fix potential parsing loop on URLs

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR