### PR TITLE
Add support for parsing semicolon-delimited "key=value" pairs in URLs…

### DIFF
--- a/unfurl/parsers/parse_url.py
+++ b/unfurl/parsers/parse_url.py
@@ -82,6 +82,67 @@ def try_url_parse(unfurl_instance, node) -> bool:
         return False
 
 
+# A run of "key=value" pairs joined by ";". Old ad servers use it inside a path segment,
+# and it was once W3C-recommended as an alternative to "&" in a query string. Every chunk
+# must be a pair and neither key nor value may contain "/", so this cannot fire on a URL or
+# on prose that happens to contain a semicolon. A value may contain "=" (ad tags routinely
+# stuff one in) but may not begin with one, which keeps runs of "="-padded base64 out.
+_semicolon_pair = r'[^/;=]+=(?:[^/;=][^/;]*)?'
+semicolon_delimited_pairs_re = re.compile(rf'(?:{_semicolon_pair};)+{_semicolon_pair};?')
+
+
+def value_came_from_a_query_string(unfurl_instance, node) -> bool:
+    """Whether this node's value was carried in a query string, rather than in the path.
+
+    "+" stands for a space in a query string and for a literal plus everywhere else, so a
+    pair lifted out of a path segment must not inherit the query-string reading. The
+    node's own data_type cannot answer this -- pairs from the path and from the query are
+    deliberately the same type, so that the parsers keyed on query pairs see both -- so
+    walk up to the nearest ancestor that names the part of the URL the value came from.
+
+    Defaults to True when nothing in the chain says: a bare "a=b&c=d" string of unknown
+    provenance is query-shaped, and that is the reading it has always been given here.
+    """
+    for ancestor in unfurl_instance.get_predecessor_chain(node):
+        if ancestor.data_type in ('url.query', 'url.fragment'):
+            return True
+        if ancestor.data_type in ('url.path', 'url.path.segment', 'url.params'):
+            return False
+
+    return True
+
+
+def try_semicolon_delimited_pairs(unfurl_instance, node) -> bool:
+    """Add a node per pair if the whole value is a run of ";"-delimited "key=value" pairs.
+
+    Requires every chunk to be a pair, so a value is either entirely this shape or left
+    alone -- a partial match would mean guessing which semicolons are separators.
+    """
+    if not isinstance(node.value, str):
+        return False
+
+    if not semicolon_delimited_pairs_re.fullmatch(node.value):
+        return False
+
+    for pair in node.value.split(';'):
+        # A trailing ";" is common in ad tags; it terminates the run rather than
+        # introducing an empty pair.
+        if not pair:
+            continue
+
+        # The key is everything up to the first "=", so a value containing its own "="
+        # stays intact instead of being split into a key that was never there.
+        key, _, value = pair.partition('=')
+        unfurl_instance.add_to_queue(
+            data_type='url.query.pair', key=key, value=value, label=f'{key}: {value}',
+            hover='This is one of a run of <b>";"-delimited "key=value" pairs</b>. Ad servers '
+                  'commonly use <br>them inside a path segment, and "<b>;</b>" was once '
+                  'W3C-recommended as an <br>alternative to "&" in a query string.',
+            parent_id=node.node_id, incoming_edge_config=urlparse_edge)
+
+    return True
+
+
 def run(unfurl, node):
 
     if not node.data_type.startswith('url'):
@@ -236,15 +297,45 @@ def run(unfurl, node):
                     parent_id=node.node_id, incoming_edge_config=urlparse_edge)
 
     elif node.data_type == 'url.params':
-        split_params_re = re.compile(r'^(?P<key>[^=]+?)=(?P<value>[^=?]+)(?P<delim>[;,|])')
+        # The value may be empty ("idfa=;c=1" is a parameter the server was sent blank,
+        # not one it was not sent), so requiring a character here would match nothing and
+        # drop the whole run -- including the pairs that are well-formed.
+        split_params_re = re.compile(r'^(?P<key>[^=]+?)=(?P<value>[^=?]*)(?P<delim>[;,|])')
         split_params = split_params_re.match(node.value)
         if split_params:
+            # Path parameters are emitted as query pairs so that the parsers keyed on
+            # query pairs see them too; the hover says where they actually came from, and
+            # value_came_from_a_query_string() keeps "+" literal for them.
+            path_param_hover = (
+                'This is a <b>path parameter</b>, per <a href="'
+                'https://tools.ietf.org/html/rfc3986" target="_blank">RFC3986</a>. It sits '
+                'in the URL path rather than the query string, so a "+" in its value '
+                'is a literal plus.')
+
             x = split_params.group('delim')
             parsed_params = node.value.split(x)
             for parsed_param in parsed_params:
+                # A trailing delimiter terminates the run; it is not an empty parameter.
+                if not parsed_param:
+                    continue
+
+                # A chunk with no "=" is not a pair. Splitting it into a key with an empty
+                # value would show it identically to "<chunk>=", asserting a separator the
+                # URL never contained, so it is kept whole instead.
+                if '=' not in parsed_param:
+                    unfurl.add_to_queue(
+                        data_type='string', key=None, value=parsed_param,
+                        hover='This is one of the <b>path parameters</b>, per <a href="'
+                              'https://tools.ietf.org/html/rfc3986" target="_blank">RFC3986'
+                              '</a>. It is not a "key=value" pair, so it is shown as it '
+                              'was written.',
+                        parent_id=node.node_id, incoming_edge_config=urlparse_edge)
+                    continue
+
                 key, _, value = parsed_param.partition('=')
                 unfurl.add_to_queue(
-                    data_type='url.param.pair', key=key, value=value,
+                    data_type='url.query.pair', key=key, value=value,
+                    hover=path_param_hover,
                     parent_id=node.node_id, incoming_edge_config=urlparse_edge)
 
     # This should only occur when a URL node was parsed previously and netloc != hostname, which means there are
@@ -314,9 +405,16 @@ def run(unfurl, node):
                 return
 
         # If the query pair value is itself a URL, parse it as one.
-        if not try_url_parse(unfurl, node):
-            # This is a query string, so "+" here really does mean a space.
-            try_url_unquote(unfurl, node, plus_is_space=True)
+        if try_url_parse(unfurl, node):
+            return
+
+        # A value can hold a run of ";"-delimited pairs of its own (a=1;b=2;c=3).
+        if try_semicolon_delimited_pairs(unfurl, node):
+            return
+
+        # "+" only means a space if this pair really came from a query string.
+        try_url_unquote(
+            unfurl, node, plus_is_space=value_came_from_a_query_string(unfurl, node))
 
     elif node.data_type == 'url.path.segment':
         match = lookup_extension(node.value)
@@ -344,6 +442,11 @@ def run(unfurl, node):
                 data_type='file.ext', key='File Extension', value=extension,
                 hover=hover,
                 parent_id=node.node_id, incoming_edge_config=urlparse_edge)
+
+        # RFC 3986 calls a ";"-delimited run inside a segment the path parameters, but
+        # urlparse only splits them off the *last* segment, so a run in any earlier one
+        # (which is where ad servers put theirs) arrives here still joined.
+        try_semicolon_delimited_pairs(unfurl, node)
 
     else:
         if not isinstance(node.value, str):
@@ -375,6 +478,10 @@ def run(unfurl, node):
         m = amp_delimited_pairs_re.fullmatch(node.value)
         if m:
             parse_delimited_string(unfurl, node, delimiter='&', pairs=True)
+            return
+
+        # If the value contains more pairs of the form "a=b;c=d;e=f"
+        if try_semicolon_delimited_pairs(unfurl, node):
             return
 
         try_url_unquote(unfurl, node)

--- a/unfurl/tests/unit/test_url.py
+++ b/unfurl/tests/unit/test_url.py
@@ -268,5 +268,210 @@ class TestUrlUnquoting(unittest.TestCase):
         self.assertEqual(corrupted, [])
 
 
+class TestSemicolonDelimitedPairs(unittest.TestCase):
+    """A run of ";"-delimited "key=value" pairs is decomposed into a node per pair.
+
+    Ad servers put these inside a path segment, where urlparse leaves them joined:
+    it splits path parameters off the *last* segment only, and the last segment of a
+    click tracker is rarely the one carrying them.
+    """
+
+    class FakeNode:
+        node_id = 1
+
+        def __init__(self, value):
+            self.value = value
+
+    def split(self, value):
+        """Return whether `value` was split, and the pairs it was split into."""
+        test = Unfurl()
+        matched = parse_url.try_semicolon_delimited_pairs(test, self.FakeNode(value))
+        emitted = [(item['key'], item['value']) for item in list(test.queue.queue)]
+        return matched, emitted
+
+    def test_pairs_are_split(self):
+        matched, emitted = self.split('a=1;b=2;c=3')
+        self.assertTrue(matched)
+        self.assertEqual([('a', '1'), ('b', '2'), ('c', '3')], emitted)
+
+    def test_empty_values_are_kept(self):
+        """"idfa=" is a parameter the tracker sent empty, not one it left out."""
+        matched, emitted = self.split('idfa=;cid=;p=1')
+        self.assertTrue(matched)
+        self.assertEqual([('idfa', ''), ('cid', ''), ('p', '1')], emitted)
+
+    def test_trailing_semicolon_is_a_terminator(self):
+        """Ad tags often end with ";"; it does not introduce an empty pair."""
+        matched, emitted = self.split('a=1;b=2;')
+        self.assertTrue(matched)
+        self.assertEqual([('a', '1'), ('b', '2')], emitted)
+
+    def test_value_may_contain_its_own_equals(self):
+        """The key is everything up to the first "="; the rest of the chunk is the value."""
+        matched, emitted = self.split('ord=@CACHEBUSTER@redirect=https:;n=1')
+        self.assertTrue(matched)
+        self.assertEqual([('ord', '@CACHEBUSTER@redirect=https:'), ('n', '1')], emitted)
+
+    def test_values_that_are_not_a_pair_run_are_left_alone(self):
+        """Every chunk has to be a pair, so a value is split entirely or not at all.
+
+        A partial match would mean guessing which semicolons are separators, and the
+        guess would be presented with the same authority as a real decoding.
+        """
+        for value in ('a=1',                          # one pair has nothing to split
+                      'foo; bar; baz',                # prose
+                      'key=value; another thing',     # only the first chunk is a pair
+                      'cats;lang=en',                 # only the last chunk is a pair
+                      'https://a.com;https://b.com',  # URLs, not pairs
+                      'text/html;charset=utf-8',      # a media type
+                      'YWJj==;ZGVm==',                # "="-padded base64
+                      'a=1;;b=2',                     # an empty chunk mid-run
+                      'path/to/x=1;y=2',              # a path, not a pair run
+                      ''):
+            matched, emitted = self.split(value)
+            self.assertFalse(matched, msg=f'did not expect {value!r} to be split')
+            self.assertEqual([], emitted)
+
+    def test_ad_tag_in_a_path_segment(self):
+        """End to end: the click tracker this was built for.
+
+        The destination URL is unencoded, so RFC 3986 scatters it across several
+        segments; that is a separate problem. What matters here is that the tracker's
+        own parameters come apart.
+        """
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://trkn.us/click/process/partner=1086;c=11270;p=23056986;idfa=;'
+                  'cid=;ord=@CACHEBUSTER@redirect=https://curiositystream.com'
+                  '?utm_source=Audacy')
+        test.parse_queue()
+
+        pairs = {node.key: node.value for node in test.nodes.values()
+                 if node.data_type == 'url.query.pair'}
+        self.assertEqual('1086', pairs['partner'])
+        self.assertEqual('11270', pairs['c'])
+        self.assertEqual('23056986', pairs['p'])
+        self.assertEqual('', pairs['idfa'])
+        self.assertEqual('', pairs['cid'])
+        self.assertEqual('@CACHEBUSTER@redirect=https:', pairs['ord'])
+
+        # The segment the pairs came from is still shown unaltered.
+        segments = [node.value for node in test.nodes.values()
+                    if node.data_type == 'url.path.segment']
+        self.assertIn(
+            'partner=1086;c=11270;p=23056986;idfa=;cid=;ord=@CACHEBUSTER@redirect=https:',
+            segments)
+
+    def test_pair_run_inside_a_query_parameter(self):
+        """A query parameter whose value is itself a run of pairs."""
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://example.com/page?data=a%3D1%3Bb%3D2%3Bc%3D3')
+        test.parse_queue()
+
+        pairs = {node.key: node.value for node in test.nodes.values()
+                 if node.data_type == 'url.query.pair'}
+        self.assertEqual('a=1;b=2;c=3', pairs['data'])
+        self.assertEqual('1', pairs['a'])
+        self.assertEqual('2', pairs['b'])
+        self.assertEqual('3', pairs['c'])
+
+    def test_semicolon_in_a_query_value_is_not_split(self):
+        """"?q=cats;lang=en" is one parameter whose value contains a semicolon.
+
+        Semicolon was once an accepted query separator, so this could be read as two
+        parameters -- but nothing in the URL says which reading is right, and "cats"
+        is not a pair, so the value is left as the server would have received it.
+        """
+
+        test = Unfurl()
+        test.add_to_queue(
+            data_type='url', key=None, value='https://example.com/search?q=cats;lang=en')
+        test.parse_queue()
+
+        pairs = {node.key: node.value for node in test.nodes.values()
+                 if node.data_type == 'url.query.pair'}
+        self.assertEqual({'q': 'cats;lang=en'}, pairs)
+
+
+class TestPathParameters(unittest.TestCase):
+    """RFC 3986 path parameters -- the ";" run urlparse splits off the last path segment.
+
+    They are emitted as query pairs so the parsers keyed on query pairs see them too; a
+    "utm_source" is the same thing wherever in the URL it was carried. What does differ
+    is "+", which is a space in a query string and a literal plus in a path.
+    """
+
+    @staticmethod
+    def pairs_for(url):
+        test = Unfurl()
+        test.add_to_queue(data_type='url', key=None, value=url)
+        test.parse_queue()
+        return test, {node.key: node.value for node in test.nodes.values()
+                      if node.data_type == 'url.query.pair'}
+
+    def test_empty_value_does_not_drop_the_run(self):
+        """"idfa=" is a parameter sent blank, not a parameter left out.
+
+        The detection regex used to require a character of value before the delimiter,
+        so a run containing an empty one matched nothing and every pair in it was lost,
+        including the well-formed ones.
+        """
+        _, pairs = self.pairs_for('https://example.com/a/x;partner=1086;idfa=;c=1')
+        self.assertEqual('1086', pairs['partner'])
+        self.assertEqual('', pairs['idfa'])
+        self.assertEqual('1', pairs['c'])
+
+    def test_run_without_an_empty_value_still_works(self):
+        _, pairs = self.pairs_for('https://example.com/a/x;c=11270;p=23056986')
+        self.assertEqual('11270', pairs['c'])
+        self.assertEqual('23056986', pairs['p'])
+
+    def test_trailing_delimiter_is_a_terminator(self):
+        test, pairs = self.pairs_for('https://example.com/a/x;a=1;b=2;')
+        self.assertEqual({'a': '1', 'b': '2'}, pairs)
+        self.assertNotIn('', [node.key for node in test.nodes.values()])
+
+    def test_chunk_without_an_equals_is_not_shown_as_a_pair(self):
+        """"garbage" and "garbage=" are different inputs and must not render alike.
+
+        Splitting a chunk that has no "=" into a key with an empty value would assert a
+        separator the URL never contained, so it is kept whole instead.
+        """
+        test, pairs = self.pairs_for('https://example.com/a/x;a=1;garbage;b=2')
+        self.assertEqual({'a': '1', 'b': '2'}, pairs)
+        self.assertIn('garbage', [node.value for node in test.nodes.values()
+                                  if node.data_type == 'string'])
+
+    def test_plus_in_a_path_parameter_stays_literal(self):
+        """A path parameter is not a query string, so "+" is a plus and not a space."""
+        test, pairs = self.pairs_for('https://example.com/a/x;name=a+b;c=1')
+        self.assertEqual('a+b', pairs['name'])
+        self.assertNotIn('a b', [node.value for node in test.nodes.values()
+                                 if isinstance(node.value, str)])
+
+    def test_plus_in_a_semicolon_run_in_an_earlier_segment_stays_literal(self):
+        """The same holds for a run urlparse leaves inside a path segment."""
+        test, pairs = self.pairs_for('https://example.com/click/p=a+b;c=1/end')
+        self.assertEqual('a+b', pairs['p'])
+        self.assertNotIn('a b', [node.value for node in test.nodes.values()
+                                 if isinstance(node.value, str)])
+
+    def test_plus_in_a_real_query_parameter_is_still_a_space(self):
+        """The provenance check must not switch off "+" decoding where it belongs."""
+        _, pairs = self.pairs_for('https://example.com/a/b?name=a+b')
+        self.assertEqual('a b', pairs['name'])
+
+    def test_percent_escapes_in_a_path_parameter_still_decode(self):
+        """Keeping "+" literal must not stop ordinary unquoting."""
+        test, _ = self.pairs_for('https://example.com/a/x;name=a%20b;c=1')
+        self.assertIn('a b', [node.value for node in test.nodes.values()
+                              if isinstance(node.value, str)])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
… and enhance path parameter handling

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
