### PR TITLE
Add parsing and testing for Bing URL parameters and refine hover text wrapping

### DIFF
--- a/unfurl/parsers/parse_bing.py
+++ b/unfurl/parsers/parse_bing.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2026 Ryan Benson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 bing_edge = {
     'color': {
         'color': '#228372'
@@ -20,10 +22,99 @@ bing_edge = {
     'label': 'B'
 }
 
+# The "form" codes and their meanings come from the Lantern project's parameters.md
+# (https://github.com/lanterntool/lantern/blob/main/parameters.md), the reference table
+# published alongside Spear, Hawbecker & McElyea, "Lantern to the Underworld" (HICSS 2021).
+# Upstream last verified these between 2021-05-21 and 2021-06-08, and the authors warn the
+# codes change over time, so treat them as a snapshot rather than a current guarantee.
+# Placeholder names are normalized to [searchString]/[initialSearch] to match this file.
+
+# Five codes share one meaning: which one Bing emits depends on how far the user had
+# scrolled when the "stickied" search bar appeared. Keeping them as one string keeps that
+# deliberate grouping visible instead of looking like duplicated entries.
+scrolled_suggestion_bar = \
+    "Indicates the user arrived at results by having scrolled part way down a search results page until a " \
+    "secondary \"stickied\" search bar appears at the top of the page and then selected a suggested search " \
+    "term from the list of suggestions. Which of the five IRMH codes appears depends on how far down the " \
+    "user had scrolled."
+
+form_values = {
+    "AWIR": "Indicates the user arrived at results by having selected \"Including results for [alternate version of initial search \"[searchString]\"]\" (i.e. user searched for \"Newyork\" and Bing includes additional results for \"New York\").",
+    "AWRE": "Indicates the user arrived at results by having misspelled a term and then selected \"Including results for [correct spelling]\" ",
+    "HDRSC1": "Indicates the user arrived at results by having performed a search for \"[searchString]\" not in the Bing web search and then clicking \"All\" to see all results.",
+    "HDRSC2": "Indicates the user arrived at results by having manually typed the search term \"[searchString]\" into the main Bing search engine and then selecting \"Bing Images\" to view the image search results.",
+    "HDRSC3": "Indicates the user arrived at results by having performed a search for \"[searchString]\" outside the \"Videos\" search (such as \"Images\" or \"All\") then clicking \"Videos\" to see only Video results.",
+    "IDINTS": "Indicates the user arrived at Bing image results by having selected the Bing-suggested search term \"[searchString]\" located at the top of the page, which appeared as a result of the user having selected a thumbnail image on a previous result in order to view the full-size image within the browser.",
+    "IDMHDL": "Indicates the user arrived at results by having scrolled part way down a previous image search results page until a secondary search bar dropped down from the top of the page. The user arrived at this URL by having selected [searchString] from the Bing suggestions in this secondary search bar.",
+    "IGRE": "Indicates the user arrived at Bing image results by having typed a search term into the main Bing search engine then scrolled down the results page and selected the link \"Images of [searchString]\" to view the image search results.",
+    "ILPMFT": "Indicates the user arrived at an image grid derived when a user is directed to a fresh Bing image search page. ",
+    "ILPTRD": "Indicates the user navigated directly to the Bing Images page.",
+    "ILPVIS": "Indicates the user navigated to the Bing Visual Search tool by selecting the \"Visual Search\" link on the Bing Images page.",
+    "INLIRS": "Indicates the user arrived at Bing image results by having selected the Bing-suggested search term \"[searchString]\" located in the \"Related Content\" panel on the right, which appeared as a result of the user having selected a thumbnail image on a previous result in order to view the full-size image within the browser.",
+    "IQFRML": "Indicates the user arrived at Bing image results by having typed a search term into the main Bing search engine then scrolled down the results page and selected the link \"See all images\" under the \"Images of [searchString]\" result.",
+    "IQFRBA": "Indicates the user arrived at Bing image results by having manually typed a search term into the main Bing search engine then scrolled down the results page and selected a thumbnail image beneath the link \"Images of [searchString]\" to view the image search results. The URL string also provides a unique ID for the specific image selected by the user.",
+    "IRBPRS": "Indicates the user arrived at Bing image results by having selected the suggested thumbnail of an image located at the bottom of the search results page and categorized by the Bing search engine as \"Top Suggestions for [initialSearch]\" ",
+    "IRIBEP": "Indicates the user arrived at Bing image results by having selected the Bing-suggested link within a previous image search for \"People interested in [initialSearch] also searched for\".",
+    "IRIBIP": "Indicates the user selected the thumbnail of an image categorized by the Bing search engine as \"Explore more searches like [initialSearch]\" ",
+    "IRIBPC": "Indicates the user arrived at Bing image results by having selected the suggested thumbnail of an image categorized by the Bing search engine as \"Connected to [initialSearch]\" ",
+    "IRIBQP": "Indicates the user arrived at Bing image results by having selected the suggested thumbnail of an image located at the top of the search results page and categorized by the Bing search engine as \"Top Suggestions for [initialSearch]\" ",
+    "IRMHPC": "Indicates the user arrived at Bing image results by having Search results derived from a user manually typing a search term selecting \"see more images\" at the bottom of the page, then selecting a suggested search term at the top of the page.",
+    "IRMHEP": scrolled_suggestion_bar,
+    "IRMHIP": scrolled_suggestion_bar,
+    "IRMHQP": scrolled_suggestion_bar,
+    "IRMHRE": scrolled_suggestion_bar,
+    "IRMHRS": scrolled_suggestion_bar,
+    "IRMHTS": scrolled_suggestion_bar,
+    "IRTRRL": "Indicates the user arrived at Bing image results by having selected the suggested thumbnail of an image categorized by the Bing search engine as \"Refine your search for [initialSearch]\".",
+    "IRPRST": "Indicates the user clicked on a thumbnail image visible in the results page for search \"[searchString]\" in order to view the full-size image within the browser. The \"thid\" parameter identifies the thumbnail and records whether Bing had already indexed the image (OIP) or had indexed it recently (OIF); \"mediaurl\" holds the address of the full-size image.",
+    "ISTRTH": "Indicates the user arrived at Bing image results by having selected \"[searchString]\" in Bing Images trending searches.",
+    "QBILPG": "Indicates the user arrived at Bing image results by having manually searched for \"[searchString]\" from the Bing image search page.",
+    "QBIR": "Indicates the user arrived at results by having manually input search string \"[searchString]\" on a current Bing image search result page.",
+    "QBIRMH": "Indicates the user arrived at Bing image results by having manually typed an image search term and then scrolled down the page until a secondary search bar dropped down from the top of the page before having manually typed a search for \"[searchString]\" in this secondary search bar.",
+    "R5FD2": "Indicates the user arrived at Bing image results by having selected the suggested thumbnail of an image located at the bottom of the search results page and categorized by the Bing search engine as \"People interested in [initialSearch] also searched for\" ",
+    "RCIR": "Indicates the user arrived at results by having selected \"Do you want results only for [initialSearch]\".",
+    "RESTAB": "Indicates the user arrived at results by having previously manually typed a search term and then selected the Bing-suggested search term \"[searchString]\" located at the top of the page.",
+    "Z9LH": "Indicates the user arrived at the Bing image search page by going to bing.com and selecting the \"Bing Images\" link.",
+    "Z9FD1": "Indicates the user arrived at the Bing image search page by having selected the \"Images\" link from the main bing.com web page.",
+}
+
+# Some "form" codes are a family: a documented prefix followed by the 1-based position of
+# the item the user clicked. Looking these up by exact value alone would lose the position,
+# which is the part that says *which* suggestion was taken.
+indexed_form_values = {
+    "QSRE": 'Indicates the user arrived at results by having selected related search suggestion '
+            'number {index} from the list at the bottom of a previous results page.',
+}
+
+indexed_form_re = re.compile(r'([A-Z]+?)(\d+)')
+
+
+def explain_form_value(form_value):
+    """The documented meaning of a "form" code, or None if it isn't one Unfurl knows.
+
+    Exact matches win over the indexed families so that a code like "HDRSC1", which has its
+    own entry and is not "HDRSC" item #1, keeps its specific meaning.
+    """
+
+    normalized = form_value.upper()
+
+    explanation = form_values.get(normalized)
+    if explanation:
+        return explanation
+
+    indexed_match = indexed_form_re.fullmatch(normalized)
+    if indexed_match:
+        prefix, index = indexed_match.groups()
+        template = indexed_form_values.get(prefix)
+        if template:
+            return template.format(index=int(index))
+
+    return None
+
 
 def run(unfurl, node):
     if node.data_type == 'url.query.pair':
-        if 'bing' in unfurl.find_preceding_domain(node):
+        if unfurl.preceding_domain_matches(node, 'bing.com'):
 
             # Many of the corresponding names of these QSPs were found on bing.com/as/init?pt...
             # Their function is not completely understood.
@@ -98,6 +189,10 @@ def run(unfurl, node):
             elif node.key == 'qt':
                 unfurl.add_to_queue(
                     data_type='descriptor', key=None, value=f'Timestamp: {node.value}',
+                    hover='The name comes from Bing\'s own autosuggest config, but the value is <br>'
+                          'not decoded here. Horsman (2018) reported that no embedded time and <br>'
+                          'date could be located in Bing search URLs, unlike Google\'s "ei" or <br>'
+                          'Yahoo\'s "ylc", so this should not be relied on as a verified timestamp.',
                     parent_id=node.node_id, incoming_edge_config=bing_edge)
 
             elif node.key == 'ig':
@@ -123,6 +218,91 @@ def run(unfurl, node):
             elif node.key == 'first':
                 unfurl.add_to_queue(
                     data_type='descriptor', key=None, value=f'Starting Result: {node.value}',
-                    hover='Bing search by default shows 8 results per page; higher <br>'
-                          '"first" values may indicate browsing more subsequent results pages.',
+                    hover='The index of the first result shown on the page, so higher values <br>'
+                          'mean the user paged further through the results. Results per page <br>'
+                          'varies by Bing vertical and has changed over time (Horsman (2018) <br>'
+                          'observed 10 per page for web search), so prefer this offset over a <br>'
+                          'page number derived from it.',
                     parent_id=node.node_id, incoming_edge_config=bing_edge)
+
+            elif node.key == 'thid':
+                thid_prefixes = {
+                    'OIP': 'an image Bing had already indexed',
+                    'OIF': 'an image that had been posted and indexed by Bing recently, with its '
+                           'age shown in the top left of the thumbnail',
+                }
+                thid_explanation = thid_prefixes.get(node.value.split('.')[0].upper())
+                unfurl.add_to_queue(
+                    data_type='descriptor', key=None, value=f'Thumbnail ID: {node.value}',
+                    hover='Identifies the specific thumbnail image the user clicked; seen <br>'
+                          'alongside "form=IRPRST" when a user opened a full-size image.'
+                          + (f'<br><br>This is {thid_explanation}.' if thid_explanation else ''),
+                    parent_id=node.node_id, incoming_edge_config=bing_edge)
+
+            elif node.key == 'mediaurl':
+                unfurl.add_to_queue(
+                    data_type='descriptor', key=None, value='Full-size Image URL',
+                    hover='The address of the full-size image behind the clicked thumbnail. <br>'
+                          'This is the image the user actually opened, and it usually points <br>'
+                          'off Bing to the site hosting it.',
+                    parent_id=node.node_id, incoming_edge_config=bing_edge)
+
+            elif node.key == 'sbifnm':
+                unfurl.add_to_queue(
+                    data_type='descriptor', key=None, value=f'Uploaded Image Filename: {node.value}',
+                    hover='The file name of the image the user uploaded to run a reverse image <br>'
+                          'search. This is a file name from the user\'s own system, carried in <br>'
+                          'the URL.',
+                    parent_id=node.node_id, incoming_edge_config=bing_edge)
+
+            elif node.key == 'iss':
+                iss_values = {
+                    'sbiupload': 'the user uploaded an image file to search with',
+                    'sbi': 'the user ran a search by image',
+                }
+                iss_explanation = iss_values.get(node.value.lower())
+                unfurl.add_to_queue(
+                    data_type='descriptor', key=None, value=f'Image Search Source: {node.value}',
+                    hover='How the image search was started'
+                          + (f': {iss_explanation}.' if iss_explanation
+                             else '. This specific value is not in Unfurl\'s list of known values.'),
+                    parent_id=node.node_id, incoming_edge_config=bing_edge)
+
+            elif node.key == 'view':
+                unfurl.add_to_queue(
+                    data_type='descriptor', key=None, value=f'View: {node.value}',
+                    hover='Which Bing view rendered the page; "detailv2" is the expanded image <br>'
+                          'detail pane rather than the results grid.',
+                    parent_id=node.node_id, incoming_edge_config=bing_edge)
+
+            elif node.key == 'format' and node.value.lower() == 'snrjson':
+                unfurl.add_to_queue(
+                    data_type='descriptor', key=None, value='Response Format: JSON',
+                    hover='The page asked for JSON rather than HTML, which means this URL was <br>'
+                          'fetched in the background by the page itself, not typed or clicked <br>'
+                          'as a top-level navigation. Worth distinguishing when attributing a <br>'
+                          'request to a deliberate user action.',
+                    parent_id=node.node_id, incoming_edge_config=bing_edge)
+
+            elif node.key == 'jsoncbid':
+                unfurl.add_to_queue(
+                    data_type='descriptor', key=None, value=f'JSON Callback ID: {node.value}',
+                    hover='Ties a background JSON request to the callback that consumed it; <br>'
+                          'seen alongside "format=snrjson".',
+                    parent_id=node.node_id, incoming_edge_config=bing_edge)
+
+            elif node.key.lower() == 'form':
+                form_explanation = explain_form_value(node.value)
+                if form_explanation:
+                    unfurl.add_to_queue(
+                        data_type='descriptor', key=None, value=f'Navigation Code: {node.value}',
+                        hover='The "form" parameter records how the user navigated to this '
+                              f'page. <br><br>{form_explanation}',
+                        parent_id=node.node_id, incoming_edge_config=bing_edge)
+                else:
+                    unfurl.add_to_queue(
+                        data_type='descriptor', key=None, value=f'Navigation Code: {node.value}',
+                        hover='The "form" parameter records how the user navigated to this <br>'
+                              'page (which link, suggestion, or search box they used). <br>'
+                              'This specific code is not in Unfurl\'s list of known values.',
+                        parent_id=node.node_id, incoming_edge_config=bing_edge)

--- a/unfurl/parsers/parse_url.py
+++ b/unfurl/parsers/parse_url.py
@@ -427,12 +427,7 @@ def run(unfurl, node):
                 hover += f' ({file_type.description})'
             hover += '.'
             if file_type.note:
-                # Wrap each paragraph before joining them. wrap_hover_text leaves any
-                # text that already contains a <br> alone -- the author is assumed to
-                # have chosen the breaks -- so adding the separator first would mean
-                # the note never gets wrapped at all.
-                hover = f'{utils.wrap_hover_text(hover)}<br><br>' \
-                        f'{utils.wrap_hover_text(file_type.note)}'
+                hover = f'{hover}<br><br>{file_type.note}'
 
             unfurl.add_to_queue(
                 data_type='file.name', key='File Name',

--- a/unfurl/tests/unit/test_bing.py
+++ b/unfurl/tests/unit/test_bing.py
@@ -1,9 +1,50 @@
 from unfurl.core import Unfurl
+from unfurl.parsers.parse_bing import (
+    explain_form_value, form_values, indexed_form_values, scrolled_suggestion_bar)
+import re
 import unittest
+
+
+def strip_markup(text):
+    """Text with markup removed and whitespace collapsed.
+
+    Hover text is wrapped for display, which inserts <br> at positions that depend on the
+    exact wording. Matching against the raw value makes an assertion pass or fail on where
+    a line break happened to land, so match against what the reader actually sees. Some
+    stored explanations are wrapped by hand and carry their own <br>, so expectations get
+    stripped the same way the rendered hover does.
+    """
+    return ' '.join(re.sub(r'<[^>]+>', ' ', text or '').split())
+
+
+def hover_text(node):
+    """A node's hover as the reader sees it."""
+    return strip_markup(node.hover)
+
+
+def parse(url):
+    # Remote lookups stay off: a Bing image URL carries a "mediaurl" pointing at whatever
+    # site hosted the image, and the generic URL parser recurses into it.
+    test = Unfurl(remote_lookups=False)
+    test.add_to_queue(data_type='url', key=None, value=url)
+    test.parse_queue()
+    return test
 
 
 def get_nodes_by_type(unfurl_instance, data_type):
     return [n for n in unfurl_instance.nodes.values() if n.data_type == data_type]
+
+
+def descriptors_starting_with(unfurl_instance, prefix):
+    return [n for n in unfurl_instance.nodes.values()
+            if n.data_type == 'descriptor' and str(n.value).startswith(prefix)]
+
+
+def only_descriptor(test_case, unfurl_instance, prefix):
+    """The single descriptor with this prefix, failing loudly if there isn't exactly one."""
+    nodes = descriptors_starting_with(unfurl_instance, prefix)
+    test_case.assertEqual(1, len(nodes), f'expected exactly one "{prefix}" node')
+    return nodes[0]
 
 
 class TestBing(unittest.TestCase):
@@ -26,6 +67,292 @@ class TestBing(unittest.TestCase):
 
         # is processing finished empty
         self.assertTrue(test.queue.empty())
+
+
+class TestBingFormParameter(unittest.TestCase):
+    """The "form" parameter records how a user navigated to a Bing results page.
+
+    The codes and their meanings are documented in Spear, Hawbecker & McElyea, "Lantern to
+    the Underworld" (HICSS 2021), which reverse-engineered them to timeline user actions
+    from browser history. The forensic value is entirely in the explanation text, so these
+    tests assert on the hover, not just that a node appeared.
+    """
+
+    def test_known_form_code_is_explained(self):
+        """ A documented code carries its meaning in the hover """
+
+        node = only_descriptor(
+            self, parse('https://www.bing.com/images/search?q=kittens&FORM=IDMHDL'), 'Navigation Code: ')
+
+        self.assertEqual('Navigation Code: IDMHDL', node.value)
+        hover = hover_text(node)
+        self.assertIn('records how the user navigated to this page', hover)
+        self.assertIn('secondary search bar dropped down from the top of the page', hover)
+
+    def test_unknown_form_code_still_parses_and_says_so(self):
+        """ An unrecognized code is reported, not dropped, and is labelled as unknown.
+
+        Bing's codes change over time, so an examiner will meet codes newer than Unfurl's
+        list. Staying silent about the parameter would hide evidence that is present in
+        the URL; claiming a meaning would invent one.
+        """
+
+        node = only_descriptor(
+            self, parse('https://www.bing.com/images/search?q=kittens&FORM=ZZNOPE'), 'Navigation Code: ')
+
+        self.assertEqual('Navigation Code: ZZNOPE', node.value)
+        self.assertIn("not in Unfurl's list of known values", hover_text(node))
+
+    def test_form_key_and_value_are_case_insensitive(self):
+        """ Bing sends "FORM=", but history artifacts and manual notes vary in case """
+
+        for url in ('https://www.bing.com/images/search?q=kittens&FORM=IDMHDL',
+                    'https://www.bing.com/images/search?q=kittens&form=idmhdl',
+                    'https://www.bing.com/images/search?q=kittens&Form=IdMhDl'):
+            with self.subTest(url=url):
+                hover = hover_text(only_descriptor(self, parse(url), 'Navigation Code: '))
+                self.assertIn('secondary search bar dropped down from the top of the page', hover)
+
+    def test_every_known_code_renders_its_explanation(self):
+        """ Every entry in form_values reaches the hover, so no entry is unreachable """
+
+        for code, explanation in form_values.items():
+            with self.subTest(code=code):
+                node = only_descriptor(
+                    self, parse(f'https://www.bing.com/images/search?q=kittens&FORM={code}'),
+                    'Navigation Code: ')
+
+                self.assertEqual(f'Navigation Code: {code}', node.value)
+                hover = hover_text(node)
+                self.assertNotIn("not in Unfurl's list", hover)
+                # The stored explanation has display whitespace and, where it was wrapped
+                # by hand, markup of its own; compare the collapsed forms so neither a
+                # trailing space in the table nor a hand-placed <br> fails the test.
+                self.assertIn(strip_markup(explanation), hover)
+
+    def test_form_is_only_parsed_for_bing(self):
+        """ "form" is a generic parameter name; another site's must not get Bing meanings """
+
+        other_site = parse('https://example.com/search?q=kittens&FORM=IDMHDL')
+        self.assertEqual([], descriptors_starting_with(other_site, 'Navigation Code: '))
+
+
+class TestBingIndexedFormParameter(unittest.TestCase):
+    """Some "form" codes are a prefix plus the position of the item the user clicked.
+
+    Horsman (2018) documents QSRE, where "QSRE3" means the third related-search suggestion.
+    An exact-match-only table loses the number, which is the part identifying the choice.
+    """
+
+    def test_indexed_code_keeps_its_position(self):
+        node = only_descriptor(
+            self, parse('https://www.bing.com/search?q=kittens&FORM=QSRE3'), 'Navigation Code: ')
+
+        self.assertEqual('Navigation Code: QSRE3', node.value)
+        hover = hover_text(node)
+        self.assertIn('related search suggestion number 3', hover)
+        self.assertNotIn("not in Unfurl's list", hover)
+
+    def test_each_indexed_prefix_resolves(self):
+        """ Every indexed prefix resolves, and the position is read from the code """
+
+        for prefix in indexed_form_values:
+            for index in (1, 7, 12):
+                with self.subTest(prefix=prefix, index=index):
+                    hover = hover_text(only_descriptor(
+                        self, parse(f'https://www.bing.com/search?q=kittens&FORM={prefix}{index}'),
+                        'Navigation Code: '))
+                    self.assertIn(f'number {index}', hover)
+
+    def test_exact_codes_win_over_indexed_prefixes(self):
+        """ "HDRSC1" has its own meaning and is not "HDRSC" suggestion #1 """
+
+        hover = hover_text(only_descriptor(
+            self, parse('https://www.bing.com/search?q=kittens&FORM=HDRSC1'), 'Navigation Code: '))
+
+        self.assertIn(strip_markup(form_values['HDRSC1']), hover)
+        self.assertNotIn('number 1', hover)
+
+    def test_unknown_prefix_with_a_number_is_not_invented(self):
+        """ A trailing digit alone must not manufacture a meaning """
+
+        hover = hover_text(only_descriptor(
+            self, parse('https://www.bing.com/search?q=kittens&FORM=ZZNOPE9'), 'Navigation Code: '))
+
+        self.assertIn("not in Unfurl's list of known values", hover)
+
+
+class TestBingImageDetailParameters(unittest.TestCase):
+    """Parameters that appear when a user opens a full-size image from the results grid.
+
+    The Lantern paper's timeline reads "IRPRST" together with "thid" and "mediaurl" as a
+    single user action: a thumbnail was clicked to view the full-size image.
+    """
+
+    def test_thumbnail_and_full_size_image(self):
+        test = parse('https://www.bing.com/images/search?q=kittens&FORM=IRPRST'
+                     '&thid=OIP.abc123&mediaurl=https%3A%2F%2Fexample.com%2Ffull.jpg')
+
+        self.assertEqual('Thumbnail ID: OIP.abc123',
+                         only_descriptor(self, test, 'Thumbnail ID: ').value)
+
+        media_node = only_descriptor(self, test, 'Full-size Image URL')
+        self.assertIn('the image the user actually opened', hover_text(media_node))
+
+        # The embedded address is unquoted and parsed as a URL in its own right, so the
+        # host serving the image is visible as a node rather than buried in an escape.
+        embedded = [n.value for n in get_nodes_by_type(test, 'url')]
+        self.assertIn('https://example.com/full.jpg', embedded)
+
+    def test_reverse_image_search_by_upload(self):
+        """ A reverse image search carries the name of the file the user uploaded """
+
+        test = parse('https://www.bing.com/images/search?view=detailv2'
+                     '&iss=sbiupload&sbifnm=PA.33894042.jpg')
+
+        self.assertEqual('Uploaded Image Filename: PA.33894042.jpg',
+                         only_descriptor(self, test, 'Uploaded Image Filename: ').value)
+        self.assertEqual('View: detailv2', only_descriptor(self, test, 'View: ').value)
+
+        iss_node = only_descriptor(self, test, 'Image Search Source: ')
+        self.assertIn('the user uploaded an image file to search with', hover_text(iss_node))
+
+    def test_unknown_iss_value_is_not_given_a_meaning(self):
+        iss_node = only_descriptor(
+            self, parse('https://www.bing.com/images/search?iss=somethingelse'),
+            'Image Search Source: ')
+
+        self.assertEqual('Image Search Source: somethingelse', iss_node.value)
+        self.assertIn("not in Unfurl's list of known values", hover_text(iss_node))
+
+    def test_background_json_request_is_distinguished_from_a_navigation(self):
+        """ "format=snrjson" marks a request the page made, not one the user made.
+
+        The Lantern paper's IRIBEP example is one of these. It matters when attributing a
+        URL in history to a deliberate user action.
+        """
+
+        test = parse('https://www.bing.com/images/search?q=kittens&FORM=IRIBEP'
+                     '&sid=3AB&format=snrjson&jsoncbid=2')
+
+        json_node = only_descriptor(self, test, 'Response Format: JSON')
+        self.assertIn('fetched in the background by the page itself', hover_text(json_node))
+        self.assertEqual('JSON Callback ID: 2',
+                         only_descriptor(self, test, 'JSON Callback ID: ').value)
+
+    def test_html_format_is_not_reported_as_json(self):
+        """ Only "snrjson" means a background fetch; other "format" values are left alone """
+
+        test = parse('https://www.bing.com/images/search?q=kittens&format=rss')
+        self.assertEqual([], descriptors_starting_with(test, 'Response Format'))
+
+
+class TestBingUnverifiedParameters(unittest.TestCase):
+    """Parameters Unfurl names but cannot decode should not overstate what they prove."""
+
+    def test_qt_does_not_claim_a_verified_timestamp(self):
+        """ "qt" is labelled a timestamp but is never decoded.
+
+        Horsman (2018) searched for embedded time and date data in Bing search URLs and
+        reported finding none, unlike Google's "ei" or Yahoo's "ylc". The hover has to
+        carry that caveat so an examiner does not read the raw value as a time.
+        """
+
+        hover = hover_text(only_descriptor(
+            self, parse('https://www.bing.com/search?q=kittens&qt=7'), 'Timestamp: '))
+
+        self.assertIn('not decoded here', hover)
+        self.assertIn('should not be relied on as a verified timestamp', hover)
+
+    def test_first_does_not_assert_a_page_size(self):
+        """ Results per page varies by vertical and era, so no page number is derived """
+
+        hover = hover_text(only_descriptor(
+            self, parse('https://www.bing.com/search?q=kittens&first=11'), 'Starting Result: '))
+
+        self.assertIn('index of the first result', hover)
+        self.assertNotIn('8 results per page', hover)
+
+
+class TestBingUpstreamParameterTable(unittest.TestCase):
+    """Coverage of the reference table the Lantern project publishes.
+
+    https://github.com/lanterntool/lantern/blob/main/parameters.md is the maintained list
+    behind the HICSS paper, verified upstream between 2021-05-21 and 2021-06-08. Bing's
+    codes drift, so this guards against losing coverage we already have rather than
+    asserting the table is still current.
+    """
+
+    UPSTREAM_CODES = (
+        'AWIR', 'HDRSC1', 'HDRSC2', 'HDRSC3', 'IDINTS', 'IGRE', 'ILPTRD', 'ILPVIS',
+        'INLIRS', 'IQFRBA', 'IQFRML', 'IRBPRS', 'IRIBEP', 'IRIBIP', 'IRMHEP', 'IRMHIP',
+        'IRMHRE', 'IRMHRS', 'IRMHTS', 'IRPRST', 'IRTRRL', 'ISTRTH', 'QBILPG', 'QBIR',
+        'QBIRMH', 'RCIR', 'RESTAB', 'Z9LH',
+    )
+
+    def test_every_upstream_code_is_explained(self):
+        unexplained = [code for code in self.UPSTREAM_CODES if explain_form_value(code) is None]
+        self.assertEqual([], unexplained, 'codes in upstream parameters.md with no explanation')
+
+    def test_scrolled_suggestion_codes_share_one_meaning(self):
+        """Five codes differ only by how far the user had scrolled.
+
+        Upstream documents these together: "ID will change depending on how far down the
+        user scrolled, indicated by one of the five form IDs listed here." Identical text
+        across them is deliberate, so assert the grouping rather than treating it as
+        duplication to be cleaned up.
+        """
+
+        family = ('IRMHRS', 'IRMHTS', 'IRMHIP', 'IRMHEP', 'IRMHRE')
+
+        for code in family:
+            with self.subTest(code=code):
+                self.assertEqual(scrolled_suggestion_bar, explain_form_value(code))
+
+        self.assertIn('how far down the user had scrolled', scrolled_suggestion_bar)
+
+    def test_thumbnail_id_distinguishes_freshly_indexed_images(self):
+        """The "thid" prefix says whether Bing had the image already or indexed it recently.
+
+        Upstream splits IRPRST into thid=OIP and thid=OIF for exactly this reason, and the
+        OIF case tells an examiner the image was new to Bing's index at the time.
+        """
+
+        already_indexed = hover_text(only_descriptor(
+            self, parse('https://www.bing.com/images/search?q=k&FORM=IRPRST&thid=OIP.abc123'),
+            'Thumbnail ID: '))
+        self.assertIn('an image Bing had already indexed', already_indexed)
+
+        recently_indexed = hover_text(only_descriptor(
+            self, parse('https://www.bing.com/images/search?q=k&FORM=IRPRST&thid=OIF.xyz789'),
+            'Thumbnail ID: '))
+        self.assertIn('posted and indexed by Bing recently', recently_indexed)
+
+    def test_long_form_explanation_reaches_the_reader_wrapped(self):
+        """The longest explanation is wrapped for display, with hyphenated words intact.
+
+        IRPRST is the entry that exposed two wrapping problems at once: the "form" hover
+        puts a hard break before the explanation, and the explanation contains
+        "full-size". wrap_hover_text() wraps between hard breaks rather than giving up on
+        seeing one, and does not break on hyphens, so neither shows up here.
+        """
+
+        node = only_descriptor(
+            self, parse('https://www.bing.com/images/search?q=k&FORM=IRPRST'), 'Navigation Code: ')
+
+        lines = [line for line in node.hover.split('<br>') if line.strip()]
+        self.assertGreater(len(lines), 1, 'IRPRST hover rendered as a single long line')
+        self.assertLessEqual(max(len(line) for line in lines), 70)
+        self.assertNotIn('full-<br>size', node.hover)
+        self.assertIn('full-size', node.hover)
+
+    def test_unknown_thumbnail_prefix_is_not_given_a_meaning(self):
+        hover = hover_text(only_descriptor(
+            self, parse('https://www.bing.com/images/search?q=k&thid=ZZZ.q'), 'Thumbnail ID: '))
+
+        self.assertIn('Identifies the specific thumbnail image', hover)
+        self.assertNotIn('already indexed', hover)
+        self.assertNotIn('recently', hover)
 
 
 if __name__ == '__main__':

--- a/unfurl/tests/unit/test_hover_wrapping.py
+++ b/unfurl/tests/unit/test_hover_wrapping.py
@@ -1,0 +1,143 @@
+from unfurl.utils import wrap_hover_text, wrap_width, wrap_slack
+import re
+import unittest
+
+
+def visible(text):
+    """The text with markup removed, which is what the width is meant to measure."""
+    return re.sub(r'<[^>]+>', '', text)
+
+
+def lines(wrapped):
+    return wrapped.split('<br>')
+
+
+class TestHoverWrapping(unittest.TestCase):
+
+    def test_empty_and_non_string_input(self):
+        for value in (None, '', 0, [], {}):
+            with self.subTest(value=value):
+                self.assertIsNone(wrap_hover_text(value))
+
+    def test_short_text_is_left_alone(self):
+        short = 'Search Query used in Bing'
+        self.assertEqual(short, wrap_hover_text(short))
+
+    def test_slightly_long_text_stays_on_one_line(self):
+        """One slightly long line beats a long line plus a short orphan."""
+
+        almost = 'x' * (wrap_width + wrap_slack - 1)
+        self.assertEqual(almost, wrap_hover_text(almost))
+
+    def test_long_text_is_wrapped(self):
+        text = ('Indicates the user arrived at Bing image results by having manually typed a '
+                'search term into the main Bing search engine then scrolled down the page.')
+
+        wrapped = lines(wrap_hover_text(text))
+
+        self.assertGreater(len(wrapped), 1)
+        self.assertLessEqual(max(len(line) for line in wrapped), wrap_width)
+
+
+class TestHoverWrappingHonorsAuthorBreaks(unittest.TestCase):
+    """A <br> in the source is a decision about where a line ends, not an accident."""
+
+    def test_hard_breaks_are_kept_where_they_are(self):
+        text = ('The index of the first result shown on the page.<br>'
+                'Results per page varies by Bing vertical.')
+
+        self.assertEqual(
+            ['The index of the first result shown on the page.',
+             'Results per page varies by Bing vertical.'],
+            lines(wrap_hover_text(text)))
+
+    def test_text_is_never_wrapped_across_a_hard_break(self):
+        """Two short runs stay two runs; they must not be reflowed into one line."""
+
+        text = 'Short first line.<br>Short second line.'
+        self.assertEqual(text, wrap_hover_text(text))
+
+    def test_each_run_is_wrapped_on_its_own(self):
+        """A long run next to a hard break still gets wrapped.
+
+        This is the case the old implementation could not handle: it returned any hover
+        containing a <br> untouched, so a long explanation appended after a separator was
+        never wrapped at all.
+        """
+
+        preamble = 'The "form" parameter records how the user navigated to this page.'
+        explanation = ('Indicates the user arrived at Bing image results by having manually typed '
+                       'a search term into the main Bing search engine then scrolled down the '
+                       'results page and selected a thumbnail image.')
+
+        wrapped = lines(wrap_hover_text(f'{preamble}<br><br>{explanation}'))
+
+        self.assertEqual(preamble, wrapped[0])
+        self.assertEqual('', wrapped[1], 'the blank paragraph gap should survive')
+        self.assertGreater(len(wrapped), 3, 'the explanation should have been wrapped')
+        self.assertLessEqual(max(len(line) for line in wrapped[2:]), wrap_width)
+
+    def test_paragraph_gap_is_preserved(self):
+        self.assertEqual(['a', '', 'b'], lines(wrap_hover_text('a<br><br>b')))
+
+
+class TestHoverWrappingMeasuresVisibleWidth(unittest.TestCase):
+    """Markup is held aside before wrapping, so lines are measured by what renders."""
+
+    def test_inline_tags_do_not_shorten_lines(self):
+        """<b>q</b> is 12 characters of markup for one the reader sees."""
+
+        text = ('Partial search terms entered by the user; auto-complete or suggestions may '
+                'have been used to reach the actual terms (in <b>q</b>) shown here.')
+
+        wrapped = lines(wrap_hover_text(text))
+
+        # Measured on rendered text, every line is within the width; measured on raw
+        # markup the <b> line would appear over it and get broken early.
+        self.assertLessEqual(max(len(visible(line)) for line in wrapped), wrap_width)
+        self.assertIn('<b>q</b>', wrap_hover_text(text))
+
+    def test_a_break_never_lands_inside_a_tag(self):
+        text = ('See the reference for this parameter at '
+                '<a href="https://github.com/obsidianforensics/unfurl/issues/56" target="_blank">'
+                'issue 56</a> for the full discussion of how this value was worked out.')
+
+        wrapped = lines(wrap_hover_text(text))
+
+        for line in wrapped:
+            with self.subTest(line=line):
+                self.assertEqual(line.count('<'), line.count('>'), 'a tag was split')
+
+    def test_an_anchor_is_held_whole(self):
+        anchor = ('<a href="https://github.com/obsidianforensics/unfurl/issues/56" '
+                  'target="_blank">issue 56</a>')
+        text = f'See the reference for this parameter at {anchor} for the full discussion here.'
+
+        self.assertIn(anchor, wrap_hover_text(text))
+
+    def test_a_long_href_does_not_wrap_the_text_short(self):
+        """The href's characters never render, so they must not consume the line budget."""
+
+        anchor = ('<a href="https://example.com/' + 'x' * 200 + '" target="_blank">ref</a>')
+        text = f'Short note with a reference {anchor} and a few more words after it.'
+
+        # Held aside, the visible text is short enough to stay on one line.
+        self.assertEqual(text, wrap_hover_text(text))
+
+
+class TestHoverWrappingWordBreaks(unittest.TestCase):
+
+    def test_hyphenated_words_are_not_split(self):
+        """textwrap breaks on hyphens by default, which mangles words like "full-size"."""
+
+        text = ('The user opened the full-size image within the browser after clicking a '
+                'thumbnail on the results page for that search term.')
+
+        wrapped = wrap_hover_text(text)
+
+        self.assertNotIn('full-<br>size', wrapped)
+        self.assertIn('full-size', wrapped)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unfurl/utils.py
+++ b/unfurl/utils.py
@@ -25,6 +25,10 @@ from typing import Union
 
 # A complete <a ...>...</a>, treated as one unbreakable unit when wrapping hover text.
 anchor_re = re.compile(r'<a\b[^>]*>.*?</a>', re.IGNORECASE | re.DOTALL)
+
+# Anchors are matched first so a link is held whole, link text and all; anything else
+# that looks like a tag is held on its own.
+markup_re = re.compile(rf'{anchor_re.pattern}|<[^>]+>', re.IGNORECASE | re.DOTALL)
 long_int_re = re.compile(r'\d{8,}')
 urlsafe_b64_re = re.compile(r'[A-Za-z0-9_\-]{8,}={0,2}')
 standard_b64_re = re.compile(r'[A-Za-z0-9+/]{8,}={0,2}')
@@ -152,42 +156,63 @@ def parse_ip_address(potential_ip):
     return parsed_ip
 
 
+hard_break = '<br>'
+
+# Lines are wrapped at this width, but a run only a little longer is left alone: one
+# slightly long line reads better than a long line followed by a short orphan.
+wrap_width = 60
+wrap_slack = 10
+
+
+def _wrap_hover_segment(segment: str) -> str:
+    """Wrap one run of hover text, which contains no hard line breaks of its own."""
+
+    if not segment.strip():
+        return segment
+
+    # Hold markup aside as single unbreakable tokens, so a line break can never land
+    # inside a tag and split an href in half. The placeholder is shorter than the markup
+    # it stands in for, which is what we want: lines are measured by roughly what the
+    # reader sees rather than by the length of the HTML. Anchors are held whole, link
+    # text included, so a citation is never broken across lines.
+    held = []
+
+    def hold_markup(match):
+        held.append(match.group(0))
+        return f'\x00{len(held) - 1}\x00'
+
+    stashed = markup_re.sub(hold_markup, segment)
+
+    if len(stashed) < wrap_width + wrap_slack:
+        return segment
+
+    # break_on_hyphens would split a word like "full-size" across two lines.
+    wrapped = hard_break.join(
+        textwrap.wrap(stashed, width=wrap_width, break_on_hyphens=False))
+
+    for index, markup in enumerate(held):
+        wrapped = wrapped.replace(f'\x00{index}\x00', markup)
+    return wrapped
+
+
 def wrap_hover_text(hover_text: Union[str, None]) -> Union[str, None]:
+    """Wrap hover text for display, keeping any line breaks the author wrote.
+
+    A <br> in the source is a decision about where a line should end, so wrapping happens
+    between those breaks and never across them: each run is wrapped on its own and the
+    hard breaks stay put. Width is measured against what a reader actually sees, since
+    markup is held aside first -- a hover carrying a long href or several <b> tags is not
+    wrapped short because of characters that never render.
+    """
+
     if not hover_text:
         return None
 
     if not isinstance(hover_text, str):
         return None
 
-    # If there are any manually inserted <br> or links, leave it
-    # alone. This isn't perfect detection, but it'll do.
-    if '<br' in hover_text:
-        return hover_text
-
-    # If the text is just a little long, I'd rather have it all on
-    # one line than split into one long line and a short second line
-    if len(hover_text) < 70:
-        return hover_text
-
-    # Hold each <a>...</a> aside as a single unbreakable token, so a line break can
-    # never land inside a tag and split an href in half. The placeholder is shorter
-    # than the markup it stands in for, which is what we want: lines are measured by
-    # roughly what the reader sees rather than by the length of the HTML.
-    anchors = []
-
-    def stash_anchor(match):
-        anchors.append(match.group(0))
-        return f'\x00{len(anchors) - 1}\x00'
-
-    stashed = anchor_re.sub(stash_anchor, hover_text)
-
-    # "Wrap" the hover text by splitting it into lines of length <width>,
-    # then joining them together with a <br>.
-    wrapped = '<br>'.join(textwrap.wrap(stashed, width=60))
-
-    for index, anchor in enumerate(anchors):
-        wrapped = wrapped.replace(f'\x00{index}\x00', anchor)
-    return wrapped
+    return hard_break.join(
+        _wrap_hover_segment(segment) for segment in hover_text.split(hard_break))
 
 
 def create_epoch_seconds_timestamp(


### PR DESCRIPTION
- Extended Bing parameter parsing to include detailed "form" code explanations and derived values for indexed codes.
- Added robust unit tests covering known and unknown parameters, highlighting forensic use cases and corner cases.
- Improved hover text wrapping mechanics for better display readability, supporting custom breaks and markup preservation.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR