### PR TITLE
Gate JWT detection on a decodable JOSE header

### DIFF
--- a/unfurl/parsers/parse_jwt.py
+++ b/unfurl/parsers/parse_jwt.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
 import logging
+from unfurl import utils
 
 log = logging.getLogger(__name__)
 
@@ -144,6 +146,25 @@ jwt_fields = {
 }
 
 
+def header_is_jose(encoded_header):
+    """Return True if encoded_header decodes to a JOSE header.
+
+    RFC 7515 requires the header of a JWS (and therefore of a JWT) to be a JSON
+    object carrying an "alg" member, so a value that doesn't decode that way
+    isn't a JWT no matter what shape it has.
+    """
+    header_bytes = utils.try_urlsafe_b64_decode(encoded_header)
+    if not header_bytes:
+        return False
+
+    try:
+        header = json.loads(header_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+
+    return isinstance(header, dict) and 'alg' in header
+
+
 def run(unfurl, node):
 
     if node.key in jwt_fields.keys():
@@ -168,6 +189,13 @@ def run(unfurl, node):
                         r'(?P<jwt_sig_enc>[A-Za-z0-9_\-]{8,})$')
     m = jwt_re.match(node.value)
     if m:
+        # The regex matches anything shaped like three dot-separated base64url
+        # runs, which ordinary URL path segments often are (for example
+        # "Discovery-Cove-Orlando.d6068683.Vacation-Attraction"). Decoding the
+        # header is what actually distinguishes a JWT from that shape.
+        if not header_is_jose(m['jwt_header_enc']):
+            return
+
         if m.groupdict().get('jwt_header_enc'):
             unfurl.add_to_queue(
                 data_type='jwt.header.enc', key='JWT Header', value=m['jwt_header_enc'],

--- a/unfurl/tests/unit/test_jwt.py
+++ b/unfurl/tests/unit/test_jwt.py
@@ -81,6 +81,50 @@ class TestJWT(unittest.TestCase):
         # confirm that the header was parsed as JSON
         self.assertEqual('alg', test.nodes[19].key)
 
+    def test_dotted_url_path_is_not_a_jwt(self):
+        """Don't treat a dotted URL path segment as a JWT.
+
+        Three dot-separated base64url-ish runs are a common shape for URL path
+        segments; only a decodable JOSE header makes one a JWT.
+
+        Test data source: ChatGPT ad landing URL (Expedia)
+        """
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://www.expedia.com/Discovery-Cove-Orlando.d6068683.Vacation-Attraction')
+        test.parse_queue()
+
+        # confirm no part of the path was claimed as a JWT
+        self.assertEqual(
+            [], [node.data_type for node in test.nodes.values()
+                 if node.data_type.startswith('jwt.')])
+
+        # confirm the path segment survived intact rather than being split up
+        self.assertIn(
+            'Discovery-Cove-Orlando.d6068683.Vacation-Attraction',
+            [node.value for node in test.nodes.values()])
+
+    def test_non_json_header_is_not_a_jwt(self):
+        """Don't treat a value as a JWT when its header decodes to non-JSON.
+
+        The three segments here are all valid base64url of the right length, so
+        only the header check rejects them.
+        """
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='bm90LWEtaGVhZGVy.bm90LWEtcGF5bG9hZA.bm90LWEtc2lnbmF0dXJl')
+        test.parse_queue()
+
+        self.assertEqual(
+            [], [node.data_type for node in test.nodes.values()
+                 if node.data_type.startswith('jwt.')])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The JWT parser matched on shape alone: three dot-separated runs of base64url characters, 8 or more each. Ordinary URL path segments hit that pattern regularly:

```
https://www.expedia.com/Discovery-Cove-Orlando.d6068683.Vacation-Attraction
 └─[9] 1: Discovery-Cove-Orlando.d6068683.Vacation-Attraction
    ├─(JWT)─[16] JWT Header: Discovery-Cove-Orlando
    ├─(JWT)─[17] JWT Payload: d6068683
    └─(JWT)─[18] JWT Signature: Vacation-Attraction
```

RFC 7515 requires a JWS header to be a JSON object with an `alg` member, so the fix decodes the first segment and checks for that before claiming the value. This mirrors how `parse_itsdangerous` gates on a plausible timestamp rather than on the token's shape.

Two tests added: the Expedia path, and a value whose three segments are all valid base64url but whose header is not JSON.
