### PR TITLE
Stop the CLI from crashing on a non-UTF-8 console

### DIFF
--- a/unfurl/cli.py
+++ b/unfurl/cli.py
@@ -17,10 +17,41 @@
 import argparse
 import csv
 import os
+import sys
 from unfurl import core
 
 
+def configure_output_encoding():
+    """Make the console streams able to carry unfurl's output.
+
+    The text tree is drawn with box-drawing characters, edge labels can be
+    emoji, and node values can hold anything that was in the input. Python
+    encodes stdout using the locale's encoding, which on Windows is typically
+    cp1252 and can represent none of those, so printing a tree raises
+    UnicodeEncodeError and the whole run is lost.
+
+    Switch the streams to UTF-8, unless the user set PYTHONIOENCODING, in which
+    case they have already said what they want and we leave it alone.
+    """
+    if os.environ.get('PYTHONIOENCODING'):
+        return
+
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, OSError, ValueError):
+            # Not a reconfigurable text stream (it may have been replaced with
+            # something else entirely). Settle for not raising on characters it
+            # cannot represent, if even that much is possible.
+            try:
+                stream.reconfigure(errors='replace')
+            except (AttributeError, OSError, ValueError):
+                pass
+
+
 def command_line_interface():
+    configure_output_encoding()
+
     parser = argparse.ArgumentParser(
         description='unfurl takes a URL and expands ("unfurls") it into a directed graph, extracting every '
                     'bit of information from the URL and exposing the obscured.')

--- a/unfurl/tests/unit/test_cli.py
+++ b/unfurl/tests/unit/test_cli.py
@@ -1,0 +1,96 @@
+from unfurl import cli
+import io
+import unittest
+from unittest import mock
+
+
+class FakeStream:
+    """Minimal stand-in for a text stream that records reconfigure() calls."""
+
+    def __init__(self, encoding='cp1252', fails_on_encoding=False):
+        self.encoding = encoding
+        self.errors = 'strict'
+        self.fails_on_encoding = fails_on_encoding
+        self.calls = []
+
+    def reconfigure(self, encoding=None, errors=None):
+        self.calls.append((encoding, errors))
+        if encoding is not None:
+            if self.fails_on_encoding:
+                raise ValueError('cannot change encoding')
+            self.encoding = encoding
+        if errors is not None:
+            self.errors = errors
+
+
+class TestConfigureOutputEncoding(unittest.TestCase):
+
+    def test_switches_console_streams_to_utf8(self):
+        """A cp1252 console can't encode the tree's box-drawing characters."""
+
+        out, err = FakeStream(), FakeStream()
+        with mock.patch.dict('os.environ', {}, clear=True), \
+                mock.patch.object(cli.sys, 'stdout', out), \
+                mock.patch.object(cli.sys, 'stderr', err):
+            cli.configure_output_encoding()
+
+        self.assertEqual('utf-8', out.encoding)
+        self.assertEqual('utf-8', err.encoding)
+
+    def test_respects_explicit_pythonioencoding(self):
+        """If the user set PYTHONIOENCODING, that choice wins."""
+
+        out = FakeStream()
+        with mock.patch.dict('os.environ', {'PYTHONIOENCODING': 'cp1252'}), \
+                mock.patch.object(cli.sys, 'stdout', out):
+            cli.configure_output_encoding()
+
+        self.assertEqual([], out.calls)
+        self.assertEqual('cp1252', out.encoding)
+
+    def test_falls_back_to_replacing_unencodable_characters(self):
+        """A stream that won't change encoding should at least stop raising."""
+
+        out = FakeStream(fails_on_encoding=True)
+        with mock.patch.dict('os.environ', {}, clear=True), \
+                mock.patch.object(cli.sys, 'stdout', out):
+            cli.configure_output_encoding()
+
+        self.assertEqual('replace', out.errors)
+
+    def test_tolerates_stream_without_reconfigure(self):
+        """sys.stdout may have been replaced by something that isn't a TextIOWrapper."""
+
+        out = io.StringIO()
+        with mock.patch.dict('os.environ', {}, clear=True), \
+                mock.patch.object(cli.sys, 'stdout', out), \
+                mock.patch.object(cli.sys, 'stderr', out):
+            cli.configure_output_encoding()  # must not raise
+
+
+class TestCommandLineInterface(unittest.TestCase):
+
+    def test_tree_output_survives_a_cp1252_console(self):
+        """The end-to-end regression: unfurl a URL with stdout set to cp1252.
+
+        Before configure_output_encoding(), printing the tree raised
+        UnicodeEncodeError on the box-drawing characters.
+        """
+
+        buffer = io.TextIOWrapper(
+            io.BytesIO(), encoding='cp1252', newline='', write_through=True)
+
+        argv = ['unfurl', 'https://example.com/path?a=1']
+        with mock.patch.dict('os.environ', {}, clear=True), \
+                mock.patch.object(cli.sys, 'argv', argv), \
+                mock.patch.object(cli.sys, 'stdout', buffer):
+            cli.command_line_interface()
+
+        buffer.seek(0)
+        output = buffer.buffer.getvalue().decode('utf-8')
+        self.assertIn('Scheme: https', output)
+        self.assertIn('├', output)  # the tree's box-drawing characters
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Unfurling anything on a default Windows console failed outright:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in
position 438-439: character maps to <undefined>
```

Python encodes stdout with the locale's encoding, which is cp1252 on a default Windows install. The text tree is drawn with box-drawing characters, edge labels can be emoji, and node values can hold anything from the input, so printing a tree raised and the whole run was lost. The only workaround was setting `PYTHONIOENCODING` by hand.

Reconfigures stdout and stderr to UTF-8 at CLI startup, unless the user set `PYTHONIOENCODING`, in which case their choice stands. The `-o` CSV path already opened its file as UTF-8 and is unaffected.

Five tests added, including an end-to-end one that drives `command_line_interface()` with stdout wrapped at cp1252.
