### PR TITLE
Add a Fernet token parser

### DIFF
--- a/unfurl/parsers/__init__.py
+++ b/unfurl/parsers/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "parse_dropbox",
     "parse_facebook",
     "parse_duckduckgo",
+    "parse_fernet",
     "parse_gmail",
     "parse_google",
     "parse_hash",

--- a/unfurl/parsers/parse_fernet.py
+++ b/unfurl/parsers/parse_fernet.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Ryan Benson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unfurl import utils
+
+import logging
+log = logging.getLogger(__name__)
+
+fernet_edge = {
+    'color': {
+        'color': '#0F9B8E'
+    },
+    'title': 'Fernet Token',
+    'label': '🔐'
+}
+
+# A Fernet token is base64url of:
+#
+#     0x80 | 8-byte big-endian Unix seconds | 16-byte IV | ciphertext | 32-byte HMAC
+#
+# The timestamp sits outside the ciphertext so a recipient can enforce a TTL
+# before spending time decrypting. It is covered by the HMAC, so it cannot be
+# altered undetected, but it was never hidden: any Fernet token in a URL
+# records when it was minted, readable without the key.
+# ref: https://github.com/fernet/spec/blob/master/Spec.md
+FERNET_VERSION = 0x80
+
+# Version byte + timestamp + IV + HMAC. Everything but the ciphertext.
+FERNET_OVERHEAD = 57
+
+# The ciphertext is AES-128-CBC with PKCS7 padding, so it is always a whole
+# number of blocks, and there is always at least one.
+FERNET_BLOCK_SIZE = 16
+
+# The Fernet spec was published in 2013; a token cannot predate it.
+# (2013-01-01T00:00:00Z)
+FERNET_EPOCH_START = 1356998400
+
+# Bytes 0-8 are 0x80 followed by a timestamp whose top four bytes are zero for
+# any date between 1970 and 2106, so the payload always starts
+# 80 00 00 00 00 ..., which base64url always renders as this prefix.
+FERNET_PREFIX = 'gAAAAA'
+
+FERNET_SPEC_REF = '<a href="https://github.com/fernet/spec/blob/master/Spec.md" ' \
+                  'target="_blank">[ref]</a>'
+
+
+def _byte_length(hex_value):
+    """Length in bytes of a '0x'-prefixed hex value emitted by this parser."""
+    return (len(hex_value) - 2) // 2
+
+
+def describe_iv(value):
+    return (f'Initialization vector ({_byte_length(value)} bytes) for the '
+            f'AES-128-CBC encryption'), None
+
+
+def describe_ciphertext(value):
+    length = _byte_length(value)
+    return (f'Encrypted contents: {length} bytes, '
+            f'{length // FERNET_BLOCK_SIZE} AES blocks'), \
+        'Reading this requires the key held by whoever issued the token. The size is ' \
+        'still informative, as it bounds how much data the token can carry'
+
+
+def describe_signature(value):
+    return f'HMAC-SHA256 ({_byte_length(value)} bytes) over every preceding byte', \
+        'The issuer verifies this with a secret key to detect tampering. It covers the ' \
+        'version, timestamp, IV and ciphertext, so none of them can be altered without ' \
+        'invalidating the token'
+
+
+# Each part this parser splits out gets its meaning added underneath it on a
+# later pass, once the node exists, rather than folded into its label. That
+# keeps the node itself showing the bytes it actually holds.
+fernet_parts = {
+    'fernet.iv': describe_iv,
+    'fernet.ciphertext': describe_ciphertext,
+    'fernet.signature': describe_signature,
+}
+
+
+def decode_fernet_token(value, earliest, latest):
+    """Try to read value as a Fernet token.
+
+    Returns (payload, rewrite) where payload is the decoded bytes and rewrite
+    describes any change that had to be made to the input to decode it (None
+    if it decoded as-is). The caller splits that rewrite out as its own node so
+    the change stays visible rather than being applied silently.
+    """
+    readings = [(value, None)]
+
+    # OpenAI's ChatGPT Ads click IDs (oppref and olref) carry a trailing 'w'
+    # where a canonical Fernet token has its '=' padding, and one 'w' stands in
+    # for however many '=' there were. Only try that reading if the value does
+    # not already decode cleanly, since a token whose length needs no padding
+    # can legitimately end in 'w'.
+    if value.endswith('w'):
+        readings.append((value[:-1], "trailing 'w' read as '=' padding"))
+
+    for candidate, rewrite in readings:
+        payload = utils.try_urlsafe_b64_decode(candidate)
+        if not payload or len(payload) <= FERNET_OVERHEAD:
+            continue
+
+        if payload[0] != FERNET_VERSION:
+            continue
+
+        ciphertext_length = len(payload) - FERNET_OVERHEAD
+        if ciphertext_length % FERNET_BLOCK_SIZE:
+            continue
+
+        # The timestamp is the strongest false-positive gate. Other formats do
+        # begin with these bytes; what they do not do is carry a plausible
+        # date in them.
+        if not earliest <= int.from_bytes(payload[1:9], 'big') < latest:
+            continue
+
+        return payload, rewrite
+
+    return None, None
+
+
+def split_token(unfurl, node, payload):
+    """Split a decoded Fernet payload into its parts, beneath node."""
+
+    unfurl.add_to_queue(
+        data_type='fernet.version', key='Version', value=f'0x{payload[0]:02x}',
+        hover='Byte 0 of the token, identifying its version. <b>0x80</b> is Fernet '
+              f'version 1, the only version ever defined. {FERNET_SPEC_REF}',
+        parent_id=node.node_id, incoming_edge_config=fernet_edge)
+
+    # Queued as epoch-seconds so the timestamp parser converts it to a date,
+    # the same way the JWT parser hands off its "iat" claim.
+    unfurl.add_to_queue(
+        data_type='epoch-seconds', key='Timestamp', value=int.from_bytes(payload[1:9], 'big'),
+        hover='Bytes 1-8, a big-endian integer, holding the time the token was created. It '
+              'sits <b>outside</b> the encrypted section so a recipient can reject an '
+              'expired token without decrypting it, which is why it can be read without the '
+              'key. The signature covers it, so it cannot be altered undetected',
+        parent_id=node.node_id, incoming_edge_config=fernet_edge)
+
+    # The remaining three are opaque bytes, rendered as 0x-prefixed hex both to
+    # mark them as raw and to keep other parsers from misreading them: 64 bare
+    # hex characters look like a SHA-256 hash, and 32 with a plausible version
+    # nibble look like a UUID, which a random IV or signature sometimes is by
+    # chance.
+    unfurl.add_to_queue(
+        data_type='fernet.iv', key='IV', value=f'0x{payload[9:25].hex()}',
+        hover='Bytes 9-24 of the token',
+        parent_id=node.node_id, incoming_edge_config=fernet_edge)
+
+    unfurl.add_to_queue(
+        data_type='fernet.ciphertext', key='Ciphertext', value=f'0x{payload[25:-32].hex()}',
+        hover='Everything between the IV and the trailing signature',
+        parent_id=node.node_id, incoming_edge_config=fernet_edge)
+
+    unfurl.add_to_queue(
+        data_type='fernet.signature', key='Signature', value=f'0x{payload[-32:].hex()}',
+        hover='The last 32 bytes of the token',
+        parent_id=node.node_id, incoming_edge_config=fernet_edge)
+
+
+def run(unfurl, node):
+
+    if not isinstance(node.value, str):
+        return
+
+    # A token that had to be re-padded before it would decode. Everything the
+    # parser goes on to show was read out of this value rather than out of the
+    # value as found, so the parts are split beneath it, and nothing else in
+    # this parser needs to run on this pass.
+    if node.data_type == 'fernet.normalized':
+        payload, _ = decode_fernet_token(
+            node.value, FERNET_EPOCH_START,
+            utils.create_epoch_seconds_timestamp(days_ahead=365))
+        if payload:
+            split_token(unfurl, node, payload)
+        return
+
+    # A part split out of a token earlier, so say what it means. Doing it here
+    # rather than at creation keeps the part's own node showing its raw value.
+    if node.data_type in fernet_parts:
+        description, hover = fernet_parts[node.data_type](node.value)
+        unfurl.add_to_queue(
+            data_type='descriptor', key=None, value=description, hover=hover,
+            parent_id=node.node_id, incoming_edge_config=fernet_edge)
+        return
+
+    # Don't re-run on anything else this parser produced.
+    if node.data_type.startswith('fernet'):
+        return
+
+    # Cheap gate that keeps this parser off nearly every node it sees. Measured
+    # against a large corpus of real-world URLs, only 70 values started with
+    # this prefix, and 55 of those were Fernet tokens.
+    if not node.value.startswith(FERNET_PREFIX):
+        return
+
+    payload, rewrite = decode_fernet_token(
+        node.value, FERNET_EPOCH_START,
+        utils.create_epoch_seconds_timestamp(days_ahead=365))
+    if not payload:
+        return
+
+    node.hover = ('This looks like a <b>Fernet</b> token, a symmetric encrypt-then-MAC '
+                  'container widely used by Python web applications. Its contents are '
+                  'encrypted, but the time it was created is not, and can be read '
+                  f'without the key. {FERNET_SPEC_REF}')
+
+    if rewrite:
+        # Hand off to the branch above: the parts belong under the re-padded
+        # value they are actually read from, not under the value as found.
+        unfurl.add_to_queue(
+            data_type='fernet.normalized', key='Normalized Token', value=node.value[:-1] + '=',
+            hover='The value as found does not decode. Its trailing "w" stands in for the '
+                  '"=" padding, and with that restored it is a well-formed Fernet token. '
+                  "OpenAI's <b>oppref</b> and <b>olref</b> ChatGPT ad click IDs are written "
+                  'this way, with a single "w" for however many "=" characters the padding '
+                  'needed. The token itself is unaltered; only the padding notation differs '
+                  'from what the Fernet libraries emit',
+            parent_id=node.node_id, incoming_edge_config=fernet_edge)
+        return
+
+    split_token(unfurl, node, payload)

--- a/unfurl/tests/unit/test_fernet.py
+++ b/unfurl/tests/unit/test_fernet.py
@@ -1,0 +1,298 @@
+import base64
+import os
+
+from unfurl.core import Unfurl
+from unfurl import utils
+import unittest
+
+
+def _make_token(timestamp, ciphertext_blocks=1, version=0x80):
+    """Build a structurally valid Fernet token with a chosen timestamp."""
+    payload = (bytes([version]) + timestamp.to_bytes(8, 'big') + os.urandom(16)
+               + os.urandom(16 * ciphertext_blocks) + os.urandom(32))
+    return base64.urlsafe_b64encode(payload).decode()
+
+
+def _fernet_nodes(test):
+    return [n for n in test.nodes.values() if n.data_type.startswith('fernet')]
+
+
+class TestFernet(unittest.TestCase):
+
+    def test_fernet_token_in_query_parameter(self):
+        """Parse a canonical Fernet token sitting in a query parameter.
+
+        Test data source: a real SourceForge download link. The token's '=='
+        padding is URL-encoded as %3D%3D.
+        """
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://downloads.sourceforge.net/project/processhacker/processhacker2/'
+                  'processhacker-2.39-bin.zip?ts=gAAAAABi9QhscGoj3QZ9QlP-IrSoilvRjEhlpGfcTMHR'
+                  '-zrvaHtTCiFzmHxjRJYmUhM6010ob_LVv4ZquHSgHxcU1S3iYQMdLQ%3D%3D'
+                  '&use_mirror=ixpeering&r=https%3A%2F%2Fprocesshacker.sourceforge.io%2F')
+        test.parse_queue()
+
+        node_values = [n.value for n in test.nodes.values()]
+
+        # The creation time (2022-08-11 13:47:24 UTC) was decoded from bytes 1-8
+        self.assertIn(1660225644, node_values)
+        self.assertIn('2022-08-11 13:47:24+00:00', node_values)
+
+        # Each part carries the bytes it actually holds, rather than a summary
+        self.assertIn('0x80', node_values)
+        self.assertIn('0x706a23dd067d4253fe22b4a88a5bd18c', node_values)
+        self.assertIn('0x4865a467dc4cc1d1fb3aef687b530a21', node_values)
+
+        # ...and what those bytes mean is described beneath them
+        self.assertIn('Initialization vector (16 bytes) for the AES-128-CBC encryption',
+                      node_values)
+        self.assertIn('Encrypted contents: 16 bytes, 1 AES blocks', node_values)
+        self.assertIn('HMAC-SHA256 (32 bytes) over every preceding byte', node_values)
+
+        # A canonical token needs no rewriting, so no normalization node
+        self.assertEqual(
+            [], [n for n in test.nodes.values() if n.data_type == 'fernet.normalized'])
+
+    def test_fernet_token_in_url_path(self):
+        """Parse a Fernet token that is a URL path segment rather than a parameter.
+
+        Test data source: a real northstarhockey.com email link.
+        """
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://www.northstarhockey.com/email/gAAAAABp3C6O9v8TJ3YIClmnKuHKBsr1'
+                  'YrZNFi6d4X5cEjeuSYYlakJzuo000QzXoJvMR0BBlLrUL7lbvJtB3o9stdWH1Tp4etpLfZZj'
+                  '9-XjJlEYbx5uUSg=?to_name=Adam+Frutman')
+        test.parse_queue()
+
+        # The creation time (2026-04-12 23:45:18 UTC) was decoded
+        self.assertIn(1776037518, [n.value for n in test.nodes.values()])
+        self.assertIn('2026-04-12 23:45:18+00:00', [n.value for n in test.nodes.values()])
+
+        # This one carries two blocks of ciphertext (an 89-byte payload)
+        self.assertIn('Encrypted contents: 32 bytes, 2 AES blocks',
+                      [n.value for n in test.nodes.values()])
+
+    def test_chatgpt_ads_oppref_and_olref(self):
+        """Parse OpenAI's ChatGPT Ads click IDs, which are Fernet tokens whose
+        trailing '=' padding is written as a single 'w'.
+
+        Both parameters are minted at the same instant for one ad click. oppref
+        carries 32 bytes of ciphertext, olref 64.
+
+        Test data source: live ChatGPT ad click on an Expedia landing page,
+        captured 2026-09-10.
+        """
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://www.expedia.com/Discovery-Cove-Orlando.d6068683.Vacation-Attraction'
+                  '?oppref=gAAAAABqos5vVDWlTbIrMA0V3ZaokkilSh8qPsUPiM5EsyBxRPX8wkpICPef6hwmzAVy'
+                  'iCh4f3RTRyM8OUPQZuUefoJ7hMywnrRJkOGU88GlquI4Pql60Xsw'
+                  '&olref=gAAAAABqos5vZd7yc7z0rS3WdD5BCDF7yGDJZHABQrevHqnNO9t5pFpOLjWTJkK8cywp'
+                  'Q5F-HtvPPNf1QUV3f2oQWXhCitnaqkln2A9PTYknSuUkvQZp5OOwMO33WtN8FG-7Nw1qIPh9faim'
+                  'mTBthT8vIqbTvF_Ydgw')
+        test.parse_queue()
+
+        node_values = [n.value for n in test.nodes.values()]
+
+        # Both click IDs decode to the same second (2026-09-10 15:36:15 UTC)
+        self.assertEqual(2, node_values.count(1789054575))
+        self.assertIn('2026-09-10 15:36:15+00:00', node_values)
+
+        # The padding rewrite is shown as its own node, carrying the re-padded
+        # token, rather than being applied silently. Once per token.
+        normalized = [n for n in test.nodes.values() if n.data_type == 'fernet.normalized']
+        self.assertEqual(2, len(normalized))
+        for node in normalized:
+            self.assertTrue(node.value.endswith('='))
+            self.assertFalse(node.value.endswith('w='))
+
+        # ...and the rewrite is explained on that node's hover rather than
+        # costing an extra node
+        for node in normalized:
+            self.assertIn('trailing "w"', node.hover)
+            self.assertIn('oppref', node.hover)
+
+        # The parts are read out of the re-padded value, so they hang beneath
+        # it rather than beneath the value as found. The token node's only
+        # Fernet child is the normalized token itself.
+        for node in normalized:
+            children = {c.data_type for c in test.graph.successors(node)}
+            self.assertEqual(
+                {'fernet.version', 'epoch-seconds',
+                 'fernet.iv', 'fernet.ciphertext', 'fernet.signature'},
+                children)
+
+        for token in [n for n in test.nodes.values() if n.key in ('oppref', 'olref')]:
+            self.assertEqual(
+                ['fernet.normalized'],
+                [c.data_type for c in test.graph.successors(token)])
+
+        # The two tokens differ only in ciphertext size
+        self.assertIn('Encrypted contents: 32 bytes, 2 AES blocks', node_values)
+        self.assertIn('Encrypted contents: 64 bytes, 4 AES blocks', node_values)
+
+    def test_each_part_shows_its_bytes_and_is_described_beneath(self):
+        """Every part split out of a token keeps its raw value as the node's own
+        value, and its meaning hangs underneath it as a descriptor, rather than
+        the meaning replacing the value in a label."""
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://downloads.sourceforge.net/f.zip?ts=gAAAAABi9QhscGoj3QZ9QlP-'
+                  'IrSoilvRjEhlpGfcTMHR-zrvaHtTCiFzmHxjRJYmUhM6010ob_LVv4ZquHSgHxcU1S3i'
+                  'YQMdLQ%3D%3D')
+        test.parse_queue()
+
+        parts = {n.data_type: n for n in test.nodes.values()
+                 if n.data_type.startswith('fernet.')}
+        self.assertEqual(
+            {'fernet.version', 'fernet.iv', 'fernet.ciphertext', 'fernet.signature'},
+            set(parts))
+
+        for data_type, part in parts.items():
+            # the node shows the bytes, not a summary of them. unfurl builds the
+            # displayed label as "key: value", so the raw value has to survive
+            # into it; setting a label of our own would replace it.
+            self.assertTrue(part.value.startswith('0x'), f'{data_type} is not raw bytes')
+            self.assertIn(part.value, part.label,
+                          f'{data_type} hides its value behind a label')
+
+        # The parts whose size is worth stating get a descriptor beneath them.
+        for data_type in ('fernet.iv', 'fernet.ciphertext', 'fernet.signature'):
+            children = list(test.graph.successors(parts[data_type]))
+            self.assertEqual(
+                ['descriptor'], [c.data_type for c in children],
+                f'{data_type} is not described by a child descriptor')
+
+        # The version byte has nothing derived to add, so its meaning lives on
+        # its hover instead of costing a node.
+        self.assertEqual([], list(test.graph.successors(parts['fernet.version'])))
+        self.assertIn('only version ever defined', parts['fernet.version'].hover)
+        self.assertIn('[ref]', parts['fernet.version'].hover)
+
+    def test_google_iflsig_is_not_a_fernet_token(self):
+        """Don't fire on values that merely contain 'gAAAAA' somewhere inside.
+
+        Google's iflsig parameter embeds the substring, and is by far the most
+        common way it appears in real URLs (75% of the URLs containing it, in a
+        survey of a large corpus). Only a value that starts with it can be a
+        Fernet token.
+        """
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://www.google.com/search?q=test&source=hp&ei=HhzIaYDXDd6Txc8PzLiagQY'
+                  '&iflsig=AFdpzrgAAAAAacgqLj2YwCGGJ6yfTnbv5YV-R3LuduQx')
+        test.parse_queue()
+
+        self.assertEqual([], _fernet_nodes(test))
+
+    def test_implausible_timestamp_is_not_decoded(self):
+        """A structurally valid token dated outside the plausible range is some
+        other format that happens to share Fernet's leading bytes.
+
+        Test data source: real-world URLs, where values of this shape are the
+        most common reason a 'gAAAAA'-prefixed candidate is not a token.
+        """
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://example.com/?k=gAAAAAJnAAsAAABSTlU2LTExNDlQABB0AA4AAAACdgAE')
+        test.parse_queue()
+
+        self.assertEqual([], _fernet_nodes(test))
+
+    def test_wrong_ciphertext_length_is_not_decoded(self):
+        """Fernet's ciphertext is AES-CBC, so the payload is always 57 + 16k
+        bytes. A plausible-looking value of any other length is rejected."""
+
+        token = _make_token(1660225644)
+        # Drop four base64 characters (three bytes) to break the block alignment
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(data_type='url', key=None,
+                          value=f'https://example.com/?k={token.rstrip("=")[:-4]}')
+        test.parse_queue()
+
+        self.assertEqual([], _fernet_nodes(test))
+
+    def test_wrong_version_byte_is_not_decoded(self):
+        """Only version 0x80 has ever been defined."""
+
+        token = _make_token(1660225644, version=0x81)
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(data_type='url', key=None,
+                          value=f'https://example.com/?k={token}')
+        test.parse_queue()
+
+        self.assertEqual([], _fernet_nodes(test))
+
+    def test_far_future_token_is_not_decoded(self):
+        """The upper plausibility bound is computed at run time (a year out),
+        so unlike a hardcoded window it cannot silently expire. A token dated
+        well beyond it is still rejected."""
+
+        token = _make_token(utils.create_epoch_seconds_timestamp(days_ahead=800))
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(data_type='url', key=None,
+                          value=f'https://example.com/?k={token}')
+        test.parse_queue()
+
+        self.assertEqual([], _fernet_nodes(test))
+
+    def test_token_predating_the_fernet_spec_is_not_decoded(self):
+        """Fernet was published in 2013; a token cannot predate it."""
+
+        token = _make_token(1041379200)  # 2003-01-01
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(data_type='url', key=None,
+                          value=f'https://example.com/?k={token}')
+        test.parse_queue()
+
+        self.assertEqual([], _fernet_nodes(test))
+
+    def test_opaque_bytes_are_not_reparsed_as_other_formats(self):
+        """The IV, ciphertext and HMAC are random bytes. Rendered as bare hex
+        they would be misread downstream: 64 hex characters look like a SHA-256
+        hash, and 32 with a plausible version nibble look like a UUID."""
+
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(
+            data_type='url', key=None,
+            value='https://www.expedia.com/x?oppref=gAAAAABqos5vVDWlTbIrMA0V3ZaokkilSh8qPsUP'
+                  'iM5EsyBxRPX8wkpICPef6hwmzAVyiCh4f3RTRyM8OUPQZuUefoJ7hMywnrRJkOGU88GlquI4'
+                  'Pql60Xsw')
+        test.parse_queue()
+
+        # The IV really would match parse_uuid's pattern if emitted as bare hex
+        self.assertEqual(
+            [], [n for n in test.nodes.values() if n.data_type.startswith(('uuid', 'hash'))])
+
+        iv = [n for n in test.nodes.values() if n.data_type == 'fernet.iv']
+        self.assertEqual(1, len(iv))
+        self.assertTrue(iv[0].value.startswith('0x'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fernet is the default "encrypt this and hand it to an untrusted party" primitive in the Python ecosystem, so its tokens turn up in URLs. They are worth parsing for one reason:

> Bytes 1-8 are a big-endian Unix timestamp of the moment the token was minted, in cleartext, **outside** the ciphertext.

The spec puts it there so a recipient can enforce a TTL without decrypting. It is covered by the HMAC and cannot be altered undetected, but it was never hidden, and it reads without the key. Every such token in a history database is a second clock, independent of the browser's own `visit_time`.

### Output

```
ts: gAAAAABi9QhscGoj3QZ9QlP-...YQMdLQ==
 ├─(🔐) Version: 0x80
 ├─(🔐) Timestamp: 1660225644
 │   └─(🕓) 2022-08-11 13:47:24+00:00
 ├─(🔐) IV: 0x706a23dd067d4253fe22b4a88a5bd18c
 │   └─(🔐) Initialization vector (16 bytes) for the AES-128-CBC encryption
 ├─(🔐) Ciphertext: 0x4865a467dc4cc1d1fb3aef687b530a21
 │   └─(🔐) Encrypted contents: 16 bytes, 1 AES blocks
 └─(🔐) Signature: 0x73987c6344962652133ad35d286ff2d5bf866ab874a01f1714d52de261031d2d
     └─(🔐) HMAC-SHA256 (32 bytes) over every preceding byte
```

### Detection

Gated in order: value starts with `gAAAAA` (the base64 of the fixed 5-byte header), payload length is `57 + 16k` (AES-CBC), version byte is `0x80`, timestamp is plausible. The upper bound is computed at run time rather than hardcoded, so it cannot silently expire the way a fixed window does.

Measured against a large corpus of real-world URLs:

| Stage | Count |
|---|---|
| Contain `gAAAAA` anywhere | 3,450 |
| Value **starts** with `gAAAAA` | 70 |
| Passes every gate | 55 |

No false positives survived. The 15 rejects are caught by the timestamp and length checks. The prefix anchor does most of the work: 75% of the substring noise is Google's `iflsig` parameter, which embeds `gAAAAA` mid-value (`AFdpzr` + `gAAAAA` + `ac...`).

Those 55 tokens sat under parameters named `r`, `key`, `g`, `hash`, `ts`, `p`, `cph`, `encipherencode`, `a9epi`, and in bare path segments. That spread is why this matches on value shape rather than a parameter allowlist.

### ChatGPT Ads click IDs

OpenAI's `oppref` and `olref` are Fernet tokens whose trailing `=` padding is written as a single `w`, so they fail a strict decode. A canonical token reads `...Pql60Xs=`; the click ID reads `...Pql60Xsw`, and one `w` stands in for however many `=` there were.

They are re-padded into a `Normalized Token` node with the parts split beneath it, so the rewrite is visible rather than applied silently to evidence:

```
oppref: gAAAAABqos5v...Pql60Xsw
 └─(🔐) Normalized Token: gAAAAABqos5v...Pql60Xs=
     ├─(🔐) Version: 0x80
     ├─(🔐) Timestamp: 1789054575
     │   └─(🕓) 2026-09-10 15:36:15+00:00
     └─ ...
```

Tokens that decode as-is skip that hop entirely.

### Note on rendering

The IV, ciphertext and signature are emitted as `0x`-prefixed hex. Bare hex gets misread downstream: 64 hex characters look like a SHA-256 hash to `parse_hash`, and 32 with a plausible version nibble look like a UUID to `parse_uuid`, which a random IV satisfies by chance often enough to matter. There is a test pinning this.

### Tests

11 new, using real specimens (a SourceForge download link, a northstarhockey.com email link) plus a live ChatGPT ad click. Covers both padding forms, a token in a path segment rather than a parameter, the `iflsig` non-match, and rejection by version byte, block alignment, and both ends of the timestamp window.

Full suite: 371 unit + 3 integration, all passing.
