### PR TITLE
Keep hover text readable when markup is stripped for plain-text output

### DIFF
--- a/unfurl/core.py
+++ b/unfurl/core.py
@@ -751,7 +751,7 @@ class Unfurl:
         }
 
         if node.hover:
-            transformed['description'] = re.sub(r'<.*?>|\[.*?\]', '', node.hover)
+            transformed['description'] = utils.strip_hover_markup(node.hover)
 
         return transformed
 
@@ -810,7 +810,7 @@ class Unfurl:
             if detailed:
                 text_output += f' (type: {node.data_type})'
                 if node.hover:
-                    hover = re.sub(r'<.*?>|\[.*?\]', '', node.hover)
+                    hover = utils.strip_hover_markup(node.hover)
                     text_output += f' -- {hover}'
 
             indent += ' '
@@ -820,7 +820,7 @@ class Unfurl:
             if detailed:
                 text_output += f' (type: {node.data_type})'
                 if node.hover:
-                    hover = re.sub(r'<.*?>|\[.*?\]', '', node.hover)
+                    hover = utils.strip_hover_markup(node.hover)
                     text_output += f' -- {hover}'
 
             indent += '|  '
@@ -829,7 +829,7 @@ class Unfurl:
             if detailed:
                 text_output += f' (type: {node.data_type})'
                 if node.hover:
-                    hover = re.sub(r'<.*?>|\[.*?\]', '', node.hover)
+                    hover = utils.strip_hover_markup(node.hover)
                     text_output += f' -- {hover}'
 
             indent += '   '

--- a/unfurl/tests/unit/test_hover_wrapping.py
+++ b/unfurl/tests/unit/test_hover_wrapping.py
@@ -1,4 +1,4 @@
-from unfurl.utils import wrap_hover_text, wrap_width, wrap_slack
+from unfurl.utils import strip_hover_markup, wrap_hover_text, wrap_width, wrap_slack
 import re
 import unittest
 
@@ -137,6 +137,48 @@ class TestHoverWrappingWordBreaks(unittest.TestCase):
 
         self.assertNotIn('full-<br>size', wrapped)
         self.assertIn('full-size', wrapped)
+
+
+class TestStripHoverMarkup(unittest.TestCase):
+    """Plain-text outputs (the text tree, the 3D graph) can't render markup."""
+
+    def test_empty_and_non_string_input(self):
+        for value in (None, ''):
+            with self.subTest(value=value):
+                self.assertFalse(strip_hover_markup(value))
+
+    def test_line_break_becomes_a_space(self):
+        self.assertEqual('one two', strip_hover_markup('one<br>two'))
+
+    def test_line_break_variants_are_all_handled(self):
+        for markup in ('<br>', '<br/>', '<br />', '<BR>'):
+            with self.subTest(markup=markup):
+                self.assertEqual('one two', strip_hover_markup(f'one{markup}two'))
+
+    def test_a_run_of_breaks_collapses_to_one_space(self):
+        """core joins a cycle warning onto a hover with '<br><br>'."""
+
+        self.assertEqual('one two', strip_hover_markup('one<br><br>two'))
+
+    def test_other_tags_are_removed_without_adding_space(self):
+        self.assertEqual('a bold word', strip_hover_markup('a <b>bold</b> word'))
+
+    def test_citation_links_are_removed(self):
+        text = 'See the spec. <a href="https://example.com" target="_blank">[ref]</a>'
+        self.assertEqual('See the spec.', strip_hover_markup(text))
+
+    def test_wrapped_hover_survives_the_round_trip(self):
+        """The regression: wrap_hover_text replaces a space with '<br>', so
+        dropping the tag outright welds the words on either side together."""
+
+        text = ('JSON Web Tokens have three distinct parts: the header, payload, and '
+                'signature. The header identifies which algorithm is used to generate '
+                'the signature.')
+
+        stripped = strip_hover_markup(wrap_hover_text(text))
+
+        self.assertEqual(text, stripped)
+        self.assertNotIn('theheader', stripped)
 
 
 if __name__ == '__main__':

--- a/unfurl/utils.py
+++ b/unfurl/utils.py
@@ -29,6 +29,12 @@ anchor_re = re.compile(r'<a\b[^>]*>.*?</a>', re.IGNORECASE | re.DOTALL)
 # Anchors are matched first so a link is held whole, link text and all; anything else
 # that looks like a tag is held on its own.
 markup_re = re.compile(rf'{anchor_re.pattern}|<[^>]+>', re.IGNORECASE | re.DOTALL)
+
+# A line break in hover text, in any of the forms an author might write.
+line_break_re = re.compile(r'<br\s*/?>', re.IGNORECASE)
+
+# Markup and citation brackets, neither of which a plain-text output can render.
+plain_text_strip_re = re.compile(r'<.*?>|\[.*?\]', re.DOTALL)
 long_int_re = re.compile(r'\d{8,}')
 urlsafe_b64_re = re.compile(r'[A-Za-z0-9_\-]{8,}={0,2}')
 standard_b64_re = re.compile(r'[A-Za-z0-9+/]{8,}={0,2}')
@@ -213,6 +219,25 @@ def wrap_hover_text(hover_text: Union[str, None]) -> Union[str, None]:
 
     return hard_break.join(
         _wrap_hover_segment(segment) for segment in hover_text.split(hard_break))
+
+
+def strip_hover_markup(hover_text: Union[str, None]) -> Union[str, None]:
+    """Render hover text as plain text, for outputs that cannot show markup.
+
+    A <br> stands where a space would otherwise be, whether the author wrote it or
+    wrap_hover_text inserted it while wrapping, so it becomes a space. Deleting it
+    outright instead runs the words on either side together ("the tokenwas created").
+    Every other tag renders as nothing and is simply removed.
+    """
+
+    if not hover_text:
+        return hover_text
+
+    spaced = line_break_re.sub(' ', str(hover_text))
+    stripped = plain_text_strip_re.sub('', spaced)
+
+    # A run of breaks, or a tag sitting next to one, can leave several spaces behind.
+    return re.sub(r'\s{2,}', ' ', stripped).strip()
 
 
 def create_epoch_seconds_timestamp(


### PR DESCRIPTION
`wrap_hover_text` wraps long hovers by **replacing a space with `<br>`**. The plain-text outputs then stripped every tag with

```python
re.sub(r'<.*?>|\[.*?\]', '', node.hover)
```

which deletes that `<br>` outright and welds together the words on either side. Any hover long enough to wrap came out damaged.

### Before

```
$ unfurl -d 'https://x.com/?t=eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0MjI3Nzk2Mzh9.gzSra...'

... three distinct parts: theheader, payload, and signature. The header
identifieswhich algorithm is used to generate the signature.
```

Also seen: `holding the time the tokenwas created`, `with a secret key to detecttampering`, `so a recipient` rendered as `soa recipient`.

### After

```
... three distinct parts: the header, payload, and signature. The header
identifies which algorithm is used to generate the signature.
```

### The fix

Adds `utils.strip_hover_markup`, which turns a line break back into the space it was standing in for *before* removing the remaining tags, then collapses any run of spaces that leaves behind. It accepts `<br>`, `<br/>`, `<br />` and uppercase, since a hover may be machine-wrapped or hand-written.

The same regex was copied at four call sites in `core` (the 3D graph description, and three branches of the text tree), so they now all call the one helper.

This only affects outputs that cannot render markup. The web UI, which displays the hover as HTML, is untouched.

### Tests

7 new, in the existing `test_hover_wrapping.py`. The one that matters is the round trip, which encodes the bug directly:

```python
stripped = strip_hover_markup(wrap_hover_text(text))
self.assertEqual(text, stripped)
self.assertNotIn('theheader', stripped)
```

Full suite: 367 unit + 3 integration, all passing.
