### PR TITLE
Stop the Google parser crashing on an sxsrf value with no colon

### DIFF
--- a/unfurl/parsers/parse_google.py
+++ b/unfurl/parsers/parse_google.py
@@ -417,16 +417,29 @@ def run(unfurl, node):
 
         elif node.key == 'sxsrf':
             node.extra_options = {'widthConstraint': {'maximum': 400}}
-            sxs_0, sxs_1 = node.value.split(':', 1)
-            unfurl.add_to_queue(data_type='google.sxsrf', key=1, value=sxs_0,
-                                parent_id=node.node_id, incoming_edge_config=google_edge)
-            unfurl.add_to_queue(
-                data_type='epoch-milliseconds', key=2, value=sxs_1,
-                hover='The <b>sxsrf</b> parameter contains a timestamp, believed<br>'
-                      ' to correspond to the previous page load. <br><br>Refernces:<ul><li>'
-                      '<a href="https://twitter.com/phillmoore/status/1169846359509233664" target="_blank">'
-                      'Phill Moore on Twitter</a></li></ul>', parent_id=node.node_id,
-                incoming_edge_config=google_edge)
+
+            # sxsrf is usually "<token>:<epoch milliseconds>", but not always: it is
+            # sometimes empty, sometimes just the token with no separator, and
+            # sometimes has a separator with nothing after it. partition() handles
+            # all of those, where split(':', 1) raised ValueError on any value
+            # without a colon and took the whole parser down with it.
+            sxsrf_token, _, sxsrf_timestamp = node.value.partition(':')
+
+            if sxsrf_token:
+                unfurl.add_to_queue(data_type='google.sxsrf', key=1, value=sxsrf_token,
+                                    parent_id=node.node_id, incoming_edge_config=google_edge)
+
+            # Only the digits are a timestamp. Values recovered from page source can
+            # carry whitespace or a run-together second URL after the milliseconds,
+            # and neither should be handed to the timestamp parser.
+            if sxsrf_timestamp.isdigit():
+                unfurl.add_to_queue(
+                    data_type='epoch-milliseconds', key=2, value=sxsrf_timestamp,
+                    hover='The <b>sxsrf</b> parameter contains a timestamp, believed<br>'
+                          ' to correspond to the previous page load. <br><br>Refernces:<ul><li>'
+                          '<a href="https://twitter.com/phillmoore/status/1169846359509233664" target="_blank">'
+                          'Phill Moore on Twitter</a></li></ul>', parent_id=node.node_id,
+                    incoming_edge_config=google_edge)
 
         elif node.key == 'tbm':
             tbm_mappings = {

--- a/unfurl/tests/unit/test_google.py
+++ b/unfurl/tests/unit/test_google.py
@@ -260,5 +260,70 @@ class TestGoogleAccountParams(unittest.TestCase):
         self.assertIn('Google account index 1 (an additional signed-in account)', labels)
 
 
+class TestGoogleSxsrf(unittest.TestCase):
+    """sxsrf is usually "<token>:<epoch milliseconds>", but real values vary."""
+
+    def parse(self, url):
+        test = Unfurl()
+        test.remote_lookups = False
+        test.add_to_queue(data_type='url', key=None, value=url)
+        test.parse_queue()
+        return test
+
+    def test_sxsrf_token_and_timestamp(self):
+        test = self.parse(
+            'https://www.google.com/search?q=dfir'
+            '&sxsrf=AM9HkKkysRytfGfAU860nAXcaRYKmB-sbg%3A1703921243217')
+
+        self.assertIn('AM9HkKkysRytfGfAU860nAXcaRYKmB-sbg',
+                      [n.value for n in get_nodes_by_type(test, 'google.sxsrf')])
+
+        parsed = get_nodes_by_type(test, 'timestamp.epoch-milliseconds')
+        self.assertEqual(1, len(parsed))
+        self.assertEqual('2023-12-30 07:27:23.217+00:00', parsed[0].value)
+
+    def test_empty_sxsrf_does_not_crash(self):
+        """The regression: split(':', 1) raised ValueError and took the whole
+        Google parser down, so every other Google param on the URL was lost."""
+
+        test = self.parse('https://www.google.com/search?q=dfir&sxsrf=')
+
+        self.assertEqual([], get_nodes_by_type(test, 'google.sxsrf'))
+        self.assertEqual([], get_nodes_by_type(test, 'timestamp.epoch-milliseconds'))
+
+        # the rest of the Google parsing still ran
+        self.assertIn('Search Query: dfir',
+                      [n.value for n in get_nodes_by_type(test, 'google.q')])
+
+    def test_sxsrf_without_a_separator_is_all_token(self):
+        test = self.parse(
+            'https://www.google.com/search?q=dfir&sxsrf=ACQVn08gihCHPiTtyxcynvYW4n-Fhg2IqA')
+
+        self.assertIn('ACQVn08gihCHPiTtyxcynvYW4n-Fhg2IqA',
+                      [n.value for n in get_nodes_by_type(test, 'google.sxsrf')])
+        self.assertEqual([], get_nodes_by_type(test, 'timestamp.epoch-milliseconds'))
+
+    def test_sxsrf_with_empty_timestamp_yields_no_timestamp(self):
+        test = self.parse(
+            'https://www.google.com/search?q=dfir'
+            '&sxsrf=ADLYWILErLgXEV52cxUwWGAhHoGdPIVY9w%3A')
+
+        self.assertIn('ADLYWILErLgXEV52cxUwWGAhHoGdPIVY9w',
+                      [n.value for n in get_nodes_by_type(test, 'google.sxsrf')])
+        self.assertEqual([], get_nodes_by_type(test, 'timestamp.epoch-milliseconds'))
+
+    def test_non_numeric_sxsrf_timestamp_is_not_parsed(self):
+        """Values recovered from page source can carry a run-together second URL
+        after the milliseconds. That is not a timestamp."""
+
+        test = self.parse(
+            'https://www.google.com/search?q=dfir'
+            '&sxsrf=AM9HkKkFWLlX_hC63KqDpJwdH9M3JL7LZA%3A16957927058AAAAAZRPMUXuGEx')
+
+        self.assertIn('AM9HkKkFWLlX_hC63KqDpJwdH9M3JL7LZA',
+                      [n.value for n in get_nodes_by_type(test, 'google.sxsrf')])
+        self.assertEqual([], get_nodes_by_type(test, 'timestamp.epoch-milliseconds'))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The `sxsrf` handler assumed the value always splits in two:

```python
sxs_0, sxs_1 = node.value.split(':', 1)
```

A value with no colon raises `ValueError`. `core` catches and logs it, so nothing visibly breaks, but **the exception aborts `run()` for that node**, so every Google parameter after `sxsrf` on the same URL goes unparsed. An empty `sxsrf=` is enough to trigger it.

```
ERROR | Exception in parse_google: not enough values to unpack (expected 2, got 1)
  File "unfurl/parsers/parse_google.py", line 420, in run
    sxs_0, sxs_1 = node.value.split(':', 1)
ValueError: not enough values to unpack (expected 2, got 1)
```

### What real values look like

A survey of real-world Google URLs found **46 of 5,405 (0.85%)** that are not the plain `<token>:<epoch milliseconds>` shape:

| Shape | Example |
|---|---|
| empty | `sxsrf=` |
| token alone, no separator | `ACQVn08gihCHPiTtyxcynvYW4n-Fhg2IqA` |
| separator, nothing after | `ADLYWILErLgXEV52cxUwWGAhHoGdPIVY9w:` |
| whitespace around the timestamp | `...9n1yA:1 649159602913` |
| run-together second URL | `...JL7LZA:16957927058AAAAAZRPMUXuGEx...` |

### The fix

`partition()` never raises, and each part is emitted only when there is something to emit: the token when non-empty, the timestamp only when it is all digits. That last check keeps whitespace and appended junk out of the timestamp parser.

Verified against every shape above, no exceptions:

```
AM9HkKkysRytfGfAU860nAXcaRYKmB-sbg%3A1703921243217  token=[...]  ts=['2023-12-30 07:27:23.217+00:00']
(empty)                                             token=[]     ts=[]
ACQVn08gihCHPiTtyxcynvYW4n-Fhg2IqA                  token=[...]  ts=[]
ADLYWILErLgXEV52cxUwWGAhHoGdPIVY9w%3A               token=[...]  ts=[]
AM9HkKkFWLlX_hC63KqDpJwdH9M3JL7LZA%3A16957927058A   token=[...]  ts=[]
```

The ordinary case is unchanged.

One deliberate trade-off: a timestamp padded with whitespace (`:1716931856938 `) yields no timestamp node rather than being stripped and parsed. Stripping would silently alter the value, and these come from page-source extraction rather than from browsers, so a real history URL is unaffected.

### Tests

6 new. `sxsrf` had no test coverage at all before this. One of them asserts that the rest of the Google parsing still runs when `sxsrf` is empty, which is the behavior the crash actually broke:

```python
test = self.parse('https://www.google.com/search?q=dfir&sxsrf=')
self.assertIn('Search Query: dfir',
              [n.value for n in get_nodes_by_type(test, 'google.q')])
```

Full suite: 365 unit + 3 integration, all passing.
