### PR TITLE
Correct what the Fernet timestamp gate actually does

### DIFF
--- a/unfurl/parsers/parse_fernet.py
+++ b/unfurl/parsers/parse_fernet.py
@@ -121,9 +121,11 @@ def decode_fernet_token(value, earliest, latest):
         if ciphertext_length % FERNET_BLOCK_SIZE:
             continue
 
-        # The timestamp is the strongest false-positive gate. Other formats do
-        # begin with these bytes; what they do not do is carry a plausible
-        # date in them.
+        # An independent check on the structural gates above, rather than a
+        # stronger one. Measured against a large corpus of real-world URLs,
+        # the length checks already rejected every non-token, but they only
+        # catch values of the wrong shape: this is what would catch one that
+        # is shaped exactly right and carries a nonsense date.
         if not earliest <= int.from_bytes(payload[1:9], 'big') < latest:
             continue
 


### PR DESCRIPTION
Follow-up to #279. Comment only, no behaviour change.

The comment on the timestamp check claimed it is "the strongest false-positive gate". Measuring the gates separately against a large corpus of real-world URLs shows that is not what happens.

Of the 70 values that begin with the Fernet prefix, 15 are not tokens. In the parser's gate order, **every one of them is rejected by a length check before the timestamp is ever read**:

| First gate failed | Count |
|---|---|
| Length not `57 + 16k` | 9 |
| Payload 57 bytes or shorter | 5 |
| Invalid base64 length | 1 |
| Timestamp implausible | 0 |

The gate still earns its place. Run it first instead and it catches 13 of those 15 on its own, so the two are largely redundant in practice. The real argument for keeping it is different from the one the comment made: it is the only gate that would reject a value shaped exactly like a Fernet token but carrying a nonsense date.

The comment now says that instead.
